### PR TITLE
Split level

### DIFF
--- a/sources/libcpp56iip_opengl/iip_opengl_l3event_method.cpp
+++ b/sources/libcpp56iip_opengl/iip_opengl_l3event_method.cpp
@@ -9,6 +9,10 @@ void iip_opengl_l3event::all_view( void )
 	case E_WVIEW_TYPE_MAIN:
 		if (NULL != this->_clp_main)
 		{	    this->_clp_main->all_view(); }
+		if ((NULL != this->_clp_main)
+		&&  (NULL != this->_clp_sub)) {
+			this->_set_pos_and_zoom_from_main_to_sub();
+		}
 		break;
 	case E_WVIEW_TYPE_SUB:
 		if (NULL != this->_clp_main)
@@ -63,12 +67,15 @@ void iip_opengl_l3event::scroll_center( void )
 
 void iip_opengl_l3event::zoom_twice_at_center( void )
 {
-
 	switch (this->_e_wview_type) {
 	case E_WVIEW_TYPE_NOTHING: break;
 	case E_WVIEW_TYPE_MAIN:
 		if (NULL != this->_clp_main)
 		{	    this->_clp_main->zoom_twice_at_center(); }
+		if ((NULL != this->_clp_main)
+		&&  (NULL != this->_clp_sub)) {
+			this->_set_pos_and_zoom_from_main_to_sub();
+		}
 		break;
 	case E_WVIEW_TYPE_SUB:
 		if (NULL != this->_clp_main)
@@ -97,6 +104,10 @@ void iip_opengl_l3event::zoom_half_at_center( void )
 	case E_WVIEW_TYPE_MAIN:
 		if (NULL != this->_clp_main)
 		{	    this->_clp_main->zoom_half_at_center(); }
+		if ((NULL != this->_clp_main)
+		&&  (NULL != this->_clp_sub)) {
+			this->_set_pos_and_zoom_from_main_to_sub();
+		}
 		break;
 	case E_WVIEW_TYPE_SUB:
 		if (NULL != this->_clp_main)
@@ -126,6 +137,10 @@ void iip_opengl_l3event::zoom_up_at_center( void )
 	case E_WVIEW_TYPE_MAIN:
 		if (NULL != this->_clp_main)
 		{	    this->_clp_main->zoom_up_at_center(); }
+		if ((NULL != this->_clp_main)
+		&&  (NULL != this->_clp_sub)) {
+			this->_set_pos_and_zoom_from_main_to_sub();
+		}
 		break;
 	case E_WVIEW_TYPE_SUB:
 		if (NULL != this->_clp_main)
@@ -154,6 +169,10 @@ void iip_opengl_l3event::zoom_down_at_center( void )
 	case E_WVIEW_TYPE_MAIN:
 		if (NULL != this->_clp_main)
 		{	    this->_clp_main->zoom_down_at_center(); }
+		if ((NULL != this->_clp_main)
+		&&  (NULL != this->_clp_sub)) {
+			this->_set_pos_and_zoom_from_main_to_sub();
+		}
 		break;
 	case E_WVIEW_TYPE_SUB:
 		if (NULL != this->_clp_main)
@@ -182,6 +201,10 @@ void iip_opengl_l3event::zoom_num( long l_zoom )
 	case E_WVIEW_TYPE_MAIN:
 		if (NULL != this->_clp_main)
 		{	    this->_clp_main->zoom_num(l_zoom);}
+		if ((NULL != this->_clp_main)
+		&&  (NULL != this->_clp_sub)) {
+			this->_set_pos_and_zoom_from_main_to_sub();
+		}
 		break;
 	case E_WVIEW_TYPE_SUB:
 		if (NULL != this->_clp_main)

--- a/sources/libcpp81gts_file_browser/gtsfbro05list_level.cpp
+++ b/sources/libcpp81gts_file_browser/gtsfbro05list_level.cpp
@@ -184,7 +184,7 @@ int gtsfbro05list_level::_make_dir_or_file_level( const char *ccp_gui_main_dir, 
 		return NG;
 	}
 
-	if (0 == cl_gts_gui.ligbut_level_rgb_scan_browse_sw->value()) {
+	if (0 == cl_gts_gui.togbut_level_rgb_scan_browse_sw->value()) {
 		e_1st_main_type = E_DIR_OR_FILE_IS_DIR;
 		e_1st_sub_type = E_DIR_OR_FILE_IS_NOTHING;
 	} else {
@@ -251,7 +251,7 @@ int gtsfbro05list_level::change_level_list( void )
 	ccp_gui_main_dir= cl_gts_gui.filinp_level_dir->value();
 	ccp_gui_sub_dir = cl_gts_gui.filinp_level_rgb_scan_dir->value();
 
-	if (0 == cl_gts_gui.ligbut_level_rgb_scan_browse_sw->value()) {
+	if (0 == cl_gts_gui.togbut_level_rgb_scan_browse_sw->value()) {
 		ccp_dir = ccp_gui_main_dir;;
 	} else {
 		ccp_dir = ccp_gui_sub_dir;;
@@ -342,7 +342,7 @@ void gtsfbro05list_level::change_level_dir( const char *ccp_dir )
 		cp_gui_dir = (char *)ccp_dir;
 	}
 
-	if (0 == cl_gts_gui.ligbut_level_rgb_scan_browse_sw->value()) {
+	if (0 == cl_gts_gui.togbut_level_rgb_scan_browse_sw->value()) {
 	 cl_gts_gui.filinp_level_dir->value(cp_gui_dir);
 	 cl_gts_gui.filinp_level_dir->position(strlen(cp_gui_dir));
 	}

--- a/sources/libcpp81gts_file_browser/gtsfbro06cb_level_browse_sw.cpp
+++ b/sources/libcpp81gts_file_browser/gtsfbro06cb_level_browse_sw.cpp
@@ -4,7 +4,7 @@
 void gtsfbro06cb_level::cb_browse_sw( void )
 {
 	this->change_level_list();
-	if (cl_gts_gui.ligbut_level_rgb_scan_browse_sw->value()) {
+	if (cl_gts_gui.togbut_level_rgb_scan_browse_sw->value()) {
 		cl_gts_gui.filinp_level_dir->deactivate();
 		cl_gts_gui.filinp_level_rgb_scan_dir->activate();
 	} else {

--- a/sources/libcpp81gts_file_browser/gtsfbro06cb_level_cancel.cpp
+++ b/sources/libcpp81gts_file_browser/gtsfbro06cb_level_cancel.cpp
@@ -26,4 +26,11 @@ void gtsfbro06cb_level::cb_cancel( void )
 	表示スイッチをOFFにしない */
 	cl_gts_gui.window_x1view->hide(); /* x1 Window閉じる */
 	cl_gts_gui.window_level_browse->hide();  /* Window閉じる */
+
+	/* RGB Scan Image _full画像の保存場所指定の時の状態復元 */
+	if (cl_gts_gui.togbut_level_rgb_scan_browse_sw->value()) {
+		cl_gts_gui.togbut_level_rgb_scan_browse_sw->clear();
+		cl_gts_gui.filinp_level_dir->activate();
+		cl_gts_gui.filinp_level_rgb_scan_dir->deactivate();
+	}
 }

--- a/sources/libcpp81gts_file_browser/gtsfbro06cb_level_cancel.cpp
+++ b/sources/libcpp81gts_file_browser/gtsfbro06cb_level_cancel.cpp
@@ -25,6 +25,5 @@ void gtsfbro06cb_level::cb_cancel( void )
 	/* levelの終了に伴うx1view windowの閉じでは、
 	表示スイッチをOFFにしない */
 	cl_gts_gui.window_x1view->hide(); /* x1 Window閉じる */
-	cl_gts_gui.menite_level->clear(); /* menuのcheckを消す */
-	cl_gts_gui.window_level->hide();  /* Window閉じる */
+	cl_gts_gui.window_level_browse->hide();  /* Window閉じる */
 }

--- a/sources/libcpp81gts_file_browser/gtsfbro06cb_level_dir_up.cpp
+++ b/sources/libcpp81gts_file_browser/gtsfbro06cb_level_dir_up.cpp
@@ -5,7 +5,7 @@ void gtsfbro06cb_level::cb_dir_up( void )
 {
 	const char *ccp_crnt_dir;
 
-	if (0 == cl_gts_gui.ligbut_level_rgb_scan_browse_sw->value()) {
+	if (0 == cl_gts_gui.togbut_level_rgb_scan_browse_sw->value()) {
 	 ccp_crnt_dir = cl_gts_gui.filinp_level_dir->value();
 	} else {
 	 ccp_crnt_dir = cl_gts_gui.filinp_level_rgb_scan_dir->value();

--- a/sources/libcpp81gts_file_browser/gtsfbro06cb_level_file_or_level.cpp
+++ b/sources/libcpp81gts_file_browser/gtsfbro06cb_level_file_or_level.cpp
@@ -6,10 +6,10 @@ void gtsfbro06cb_level::cb_file_or_level( void )
 	this->change_level_list();
 
 	if (0 == cl_gts_gui.choice_level_list_form->value()) {
-		cl_gts_gui.button_level_shift_number->hide();
-		cl_gts_gui.ligbut_level_info_rgb_sub_sw->hide();
+		cl_gts_gui.button_level_shift_number->deactivate();
+		cl_gts_gui.ligbut_level_info_rgb_sub_sw->deactivate();
 	} else {
-		cl_gts_gui.button_level_shift_number->show();
-		cl_gts_gui.ligbut_level_info_rgb_sub_sw->show();
+		cl_gts_gui.button_level_shift_number->activate();
+		cl_gts_gui.ligbut_level_info_rgb_sub_sw->activate();
 	}
 }

--- a/sources/libcpp81gts_file_browser/gtsfbro06cb_level_file_or_level.cpp
+++ b/sources/libcpp81gts_file_browser/gtsfbro06cb_level_file_or_level.cpp
@@ -6,10 +6,10 @@ void gtsfbro06cb_level::cb_file_or_level( void )
 	this->change_level_list();
 
 	if (0 == cl_gts_gui.choice_level_list_form->value()) {
-		cl_gts_gui.button_level_shift_number->deactivate();
-		cl_gts_gui.ligbut_level_info_rgb_sub_sw->deactivate();
+		cl_gts_gui.menite_level_shift_number->deactivate();
+		cl_gts_gui.menite_level_view_rgb_full_sw->deactivate();
 	} else {
-		cl_gts_gui.button_level_shift_number->activate();
-		cl_gts_gui.ligbut_level_info_rgb_sub_sw->activate();
+		cl_gts_gui.menite_level_shift_number->activate();
+		cl_gts_gui.menite_level_view_rgb_full_sw->activate();
 	}
 }

--- a/sources/libcpp81gts_file_browser/gtsfbro06cb_level_init.cpp
+++ b/sources/libcpp81gts_file_browser/gtsfbro06cb_level_init.cpp
@@ -112,11 +112,11 @@ void gtsfbro06cb_level::memory_to_gui( void )
 		this->_i_list_form_memory
 	);
 	if (0 == cl_gts_gui.choice_level_list_form->value()) {
-		cl_gts_gui.button_level_shift_number->deactivate();
-		cl_gts_gui.ligbut_level_info_rgb_sub_sw->deactivate();
+		cl_gts_gui.menite_level_shift_number->deactivate();
+		cl_gts_gui.menite_level_view_rgb_full_sw->deactivate();
 	} else {
-		cl_gts_gui.button_level_shift_number->activate();
-		cl_gts_gui.ligbut_level_info_rgb_sub_sw->activate();
+		cl_gts_gui.menite_level_shift_number->activate();
+		cl_gts_gui.menite_level_view_rgb_full_sw->activate();
 	}
 
 	/* 03 Level名 */

--- a/sources/libcpp81gts_file_browser/gtsfbro06cb_level_init.cpp
+++ b/sources/libcpp81gts_file_browser/gtsfbro06cb_level_init.cpp
@@ -112,11 +112,11 @@ void gtsfbro06cb_level::memory_to_gui( void )
 		this->_i_list_form_memory
 	);
 	if (0 == cl_gts_gui.choice_level_list_form->value()) {
-		cl_gts_gui.button_level_shift_number->hide();
-		cl_gts_gui.ligbut_level_info_rgb_sub_sw->hide();
+		cl_gts_gui.button_level_shift_number->deactivate();
+		cl_gts_gui.ligbut_level_info_rgb_sub_sw->deactivate();
 	} else {
-		cl_gts_gui.button_level_shift_number->show();
-		cl_gts_gui.ligbut_level_info_rgb_sub_sw->show();
+		cl_gts_gui.button_level_shift_number->activate();
+		cl_gts_gui.ligbut_level_info_rgb_sub_sw->activate();
 	}
 
 	/* 03 Level名 */

--- a/sources/libcpp81gts_file_browser/gtsfbro06cb_level_list.cpp
+++ b/sources/libcpp81gts_file_browser/gtsfbro06cb_level_list.cpp
@@ -45,7 +45,7 @@ void gtsfbro06cb_level::cb_list( void )
 		i_dir_sw = ON;
 	}
 
-	if (0 == cl_gts_gui.ligbut_level_rgb_scan_browse_sw->value()) {
+	if (0 == cl_gts_gui.togbut_level_rgb_scan_browse_sw->value()) {
 	 ccp_crnt_dir = cl_gts_gui.filinp_level_dir->value();
 	} else {
 	 ccp_crnt_dir = cl_gts_gui.filinp_level_rgb_scan_dir->value();
@@ -128,7 +128,7 @@ void gtsfbro06cb_level::cb_list( void )
 
 	/* ディレクトリでなければファイルである */
 	i_list_num = cl_gts_gui.selbro_level_list->value() - 1;
-	if (0 == cl_gts_gui.choice_level_list_form->value()) {
+	if (0 == cl_gts_gui.choice_level_list_form->value()) {/* File表記 */
 		cl_gts_gui.strinp_level_file->value(cp_dir_or_file);
 
 		/* 画像情報を表示する */
@@ -142,7 +142,7 @@ void gtsfbro06cb_level::cb_list( void )
 			return;
 		}
 	}
-	/* level表記のとき */
+	/* Level表記のとき */
 	else {
 		cl_gts_gui.strinp_level_file->value(
 			this->cp_dir_or_level_name( i_list_num )
@@ -153,6 +153,10 @@ void gtsfbro06cb_level::cb_list( void )
 		cl_gts_gui.valinp_level_end->value(
 			this->i_dir_or_level_end(i_list_num)
 		);
+		/* End/EndressをEndに設定 */
+		cl_gts_gui.choice_level_continue_type->value(0);
+		cl_gts_gui.valinp_level_end->show();
+		cl_gts_gui.choice_level_endless_direction->hide();
 
 		/* levelと画像情報を表示する */
 		if (OK != this->_list_image_info(

--- a/sources/libcpp81gts_file_browser/gtsfbro06cb_level_list_image.cpp
+++ b/sources/libcpp81gts_file_browser/gtsfbro06cb_level_list_image.cpp
@@ -250,11 +250,18 @@ int gtsfbro06cb_level::_image_by_dir_and_file( const char *ccp_dir, const char *
 	t_start = clock() - t_start;
 		/* 123456789012345678901234567 */
 		/* 10.123%(100x100)(10.123sec) */
+/*
 	snprintf( ca32,32,"%7.3f%%(%ldx%ld)(%.3gsec)",
 		d_scale*100.0,
 		clp_iip_scal->get_l_width(),
 		clp_iip_scal->get_l_height(),
 		(double)t_start/CLOCKS_PER_SEC
+	);
+*/
+	snprintf( ca32,32,"Zoom %7.3f%%(%ldx%ld)"
+		, d_scale*100.0
+		, clp_iip_scal->get_l_width()
+		, clp_iip_scal->get_l_height()
 	);
 	cl_gts_gui.box_level_image->label( ca32 );
 	cl_gts_gui.box_level_image->redraw();

--- a/sources/libcpp81gts_file_browser/gtsfbro06cb_level_list_image_info.cpp
+++ b/sources/libcpp81gts_file_browser/gtsfbro06cb_level_list_image_info.cpp
@@ -148,7 +148,7 @@ int gtsfbro06cb_level::_info_image_by_dir_and_file( const char *ccp_dir, const c
 	// this->text_add("\n");
 
 	/* 画像表示 */
-	if (cl_gts_gui.ligbut_level_view_sw->value()) {
+	if (cl_gts_gui.menite_level_view_sw->value()) {
 	 cl_gts_gui.box_level_image->show();
 	 cl_gts_gui.box_level_x1view->show();
 	 if (OK != this->_image_by_dir_and_file( ccp_dir, ccp_file )) {
@@ -177,10 +177,10 @@ int gtsfbro06cb_level::_info_image_by_dir_and_num( const char *ccp_file_for_head
 /***pri_funct_msg_vr( "%s %d : ligut_level_info_rgb_sub<%d> <%s>",
 __FILE__,
 __LINE__,
-cl_gts_gui.ligbut_level_info_rgb_sub_sw->value(),
+cl_gts_gui.menite_level_view_rgb_full_sw->value(),
 cl_gts_gui.filinp_level_rgb_scan_dir->value()
 );***/
-	if (cl_gts_gui.ligbut_level_info_rgb_sub_sw->value()) {
+	if (cl_gts_gui.menite_level_view_rgb_full_sw->value()) {
 		ccp_gui_dir =
 			cl_gts_gui.filinp_level_rgb_scan_dir->value();
 		if (OK != this->i_lpath_cat_file_for_full(

--- a/sources/libcpp81gts_file_browser/gtsfbro06cb_level_mkdir.cpp
+++ b/sources/libcpp81gts_file_browser/gtsfbro06cb_level_mkdir.cpp
@@ -44,7 +44,7 @@ void gtsfbro06cb_level::cb_mkdir( void )
 	char ca_subdir[PTBL_PATH_MAX];
 
 	/* Dirを得る */
-	if (cl_gts_gui.ligbut_level_rgb_scan_browse_sw->value()) {
+	if (cl_gts_gui.togbut_level_rgb_scan_browse_sw->value()) {
 		ccp_dir = cl_gts_gui.filinp_level_rgb_scan_dir->value();
 	} else {
 		ccp_dir = cl_gts_gui.filinp_level_dir->value();

--- a/sources/libcpp81gts_file_browser/gtsfbro06cb_level_ok.cpp
+++ b/sources/libcpp81gts_file_browser/gtsfbro06cb_level_ok.cpp
@@ -99,4 +99,11 @@ void gtsfbro06cb_level::cb_ok( void )
 	表示スイッチをOFFにしない */
 	cl_gts_gui.window_x1view->hide(); /* x1 Window閉じる */
 	cl_gts_gui.window_level_browse->hide();  /* Window閉じる */
+
+	/* RGB Scan Image _full画像の保存場所指定の時の状態復元 */
+	if (cl_gts_gui.togbut_level_rgb_scan_browse_sw->value()) {
+		cl_gts_gui.togbut_level_rgb_scan_browse_sw->clear();
+		cl_gts_gui.filinp_level_dir->activate();
+		cl_gts_gui.filinp_level_rgb_scan_dir->deactivate();
+	}
 }

--- a/sources/libcpp81gts_file_browser/gtsfbro06cb_level_ok.cpp
+++ b/sources/libcpp81gts_file_browser/gtsfbro06cb_level_ok.cpp
@@ -98,6 +98,5 @@ void gtsfbro06cb_level::cb_ok( void )
 	/* levelの終了に伴うx1view windowの閉じでは、
 	表示スイッチをOFFにしない */
 	cl_gts_gui.window_x1view->hide(); /* x1 Window閉じる */
-	cl_gts_gui.menite_level->clear(); /* menuのcheckを消す */
-	cl_gts_gui.window_level->hide();  /* Window閉じる */
+	cl_gts_gui.window_level_browse->hide();  /* Window閉じる */
 }

--- a/sources/libcpp81gts_file_browser/gtsfbro06cb_level_rename_dir.cpp
+++ b/sources/libcpp81gts_file_browser/gtsfbro06cb_level_rename_dir.cpp
@@ -11,7 +11,7 @@ int gtsfbro06cb_level::_rename_dir( const char *ccp_old, char *cp_new )
 	char ca_path[PTBL_PATH_MAX];
 
 	/* Dirを得る */
-	if (cl_gts_gui.ligbut_level_rgb_scan_browse_sw->value()) {
+	if (cl_gts_gui.togbut_level_rgb_scan_browse_sw->value()) {
 		ccp_dir = cl_gts_gui.filinp_level_rgb_scan_dir->value();
 	} else {
 		ccp_dir = cl_gts_gui.filinp_level_dir->value();

--- a/sources/libcpp81gts_file_browser/gtsfbro06cb_level_wintgl.cpp
+++ b/sources/libcpp81gts_file_browser/gtsfbro06cb_level_wintgl.cpp
@@ -5,9 +5,9 @@ void gtsfbro06cb_level::cb_wintgl( void )
 {
 	this->cb_x1view_wintgl();
 	if (	cl_gts_gui.menite_level->value()) {
-		cl_gts_gui.window_level->show();
+		cl_gts_gui.window_level_set->show();
 	} else {
 		this->_cancel();
-		cl_gts_gui.window_level->hide();
+		cl_gts_gui.window_level_set->hide();
 	}
 }

--- a/sources/libcpp81gts_file_browser/gtsfbro06cb_level_x1view.cpp
+++ b/sources/libcpp81gts_file_browser/gtsfbro06cb_level_x1view.cpp
@@ -3,7 +3,7 @@
 
 void gtsfbro06cb_level::cb_x1view_cancel( void )
 {
-	cl_gts_gui.ligbut_level_image_x1_sw->value(0);
+	cl_gts_gui.ligbut_level_image_x1_sw->clear();
 	cl_gts_gui.window_x1view->hide();
 }
 

--- a/sources/libcpp81gts_file_browser/gtsfbro06cb_level_x1view.cpp
+++ b/sources/libcpp81gts_file_browser/gtsfbro06cb_level_x1view.cpp
@@ -3,13 +3,13 @@
 
 void gtsfbro06cb_level::cb_x1view_cancel( void )
 {
-	cl_gts_gui.ligbut_level_image_x1_sw->clear();
+	cl_gts_gui.menite_level_image_x1_sw->clear();
 	cl_gts_gui.window_x1view->hide();
 }
 
 void gtsfbro06cb_level::cb_x1view_wintgl( void )
 {
-	if (	cl_gts_gui.ligbut_level_image_x1_sw->value()) {
+	if (	cl_gts_gui.menite_level_image_x1_sw->value()) {
 		cl_gts_gui.window_x1view->show();
 	} else {
 		cl_gts_gui.window_x1view->hide();

--- a/sources/libcpp81gts_file_browser/gtsfbro_master.cpp
+++ b/sources/libcpp81gts_file_browser/gtsfbro_master.cpp
@@ -48,7 +48,7 @@ int gts_master::exec( void )
 	cl_gts_gui.window_opengl->position(		100,100 );
 	cl_gts_gui.window_config_load->position(	110,150 );
 	cl_gts_gui.window_config_save_as->position(	120,200 );
-	cl_gts_gui.window_level->position(		130,250 );
+	cl_gts_gui.window_level_set->position(		130,250 );
 	cl_gts_gui.window_x1view->position(		140,300 );
 	cl_gts_gui.window_trace_batch->position(	150,350 );
 

--- a/sources/libcpp83gts_callback_and_action/cb_color_trace_thickness.cpp
+++ b/sources/libcpp83gts_callback_and_action/cb_color_trace_thickness.cpp
@@ -201,32 +201,32 @@ void cb_color_trace_thickness::tgt_change_black_( E_COLOR_TRACE_HAB_COLORS trace
 	/* black off */
 	if (	      E_COLOR_TRACE_HAB_01 != trace_list_pos
 	 && cl_gts_gui.roubut_thickness_01_tgt_is_bl->value()) {
-	    cl_gts_gui.roubut_thickness_01_tgt_is_bl->value(0);
+	    cl_gts_gui.roubut_thickness_01_tgt_is_bl->clear();
 			   this->cb_enh_01();
 	}
 	if (	      E_COLOR_TRACE_HAB_02 != trace_list_pos
 	 && cl_gts_gui.roubut_thickness_02_tgt_is_bl->value()) {
-	    cl_gts_gui.roubut_thickness_02_tgt_is_bl->value(0);
+	    cl_gts_gui.roubut_thickness_02_tgt_is_bl->clear();
 			   this->cb_enh_02();
 	}
 	if (	      E_COLOR_TRACE_HAB_03 != trace_list_pos
 	 && cl_gts_gui.roubut_thickness_03_tgt_is_bl->value()) {
-	    cl_gts_gui.roubut_thickness_03_tgt_is_bl->value(0);
+	    cl_gts_gui.roubut_thickness_03_tgt_is_bl->clear();
 			   this->cb_enh_03();
 	}
 	if (	      E_COLOR_TRACE_HAB_04 != trace_list_pos
 	 && cl_gts_gui.roubut_thickness_04_tgt_is_bl->value()) {
-	    cl_gts_gui.roubut_thickness_04_tgt_is_bl->value(0);
+	    cl_gts_gui.roubut_thickness_04_tgt_is_bl->clear();
 			   this->cb_enh_04();
 	}
 	if (	      E_COLOR_TRACE_HAB_05 != trace_list_pos
 	 && cl_gts_gui.roubut_thickness_05_tgt_is_bl->value()) {
-	    cl_gts_gui.roubut_thickness_05_tgt_is_bl->value(0);
+	    cl_gts_gui.roubut_thickness_05_tgt_is_bl->clear();
 			   this->cb_enh_05();
 	}
 	if (	      E_COLOR_TRACE_HAB_06 != trace_list_pos
 	 && cl_gts_gui.roubut_thickness_06_tgt_is_bl->value()) {
-	    cl_gts_gui.roubut_thickness_06_tgt_is_bl->value(0);
+	    cl_gts_gui.roubut_thickness_06_tgt_is_bl->clear();
 			   this->cb_enh_06();
 	}
 	/* black on */

--- a/sources/libcpp83gts_callback_and_action/cb_scan_and_save.cpp
+++ b/sources/libcpp83gts_callback_and_action/cb_scan_and_save.cpp
@@ -48,8 +48,8 @@ int gts_master::next_scan_and_save_( void )
 	}
 
 	/* 05 保存する(番号に対する)ファイルパスを得る */
-	if (3L <= this->cl_iip_ro90.get_l_channels() &&
-	cl_gts_gui.chkbtn_level_rgb_with_full_sw->value() == 1
+	if (3L <= this->cl_iip_ro90.get_l_channels()
+	&& cl_gts_gui.chkbtn_level_rgb_with_full_sw->value()
 	) {
 		/* RGB画像(専用の名前)(_full付)(A_full.0001.tif) */
 		/* 読み込み(番号に対する)ファイルパスを得る */
@@ -73,9 +73,9 @@ int gts_master::next_scan_and_save_( void )
 	}
 
 	/* 06 BWか、Grayscaleか、RGBで保存SWがONのどれかの場合 */
-	if ((this->cl_iip_ro90.get_l_channels() < 3L) ||//BW or Grayscale
-	    (this->cl_iip_ro90.get_l_channels() == 3L &&//RGB & SW is ON
-	     cl_gts_gui.chkbtn_level_rgb_full_save_sw->value() == 1
+	if ((this->cl_iip_ro90.get_l_channels() < 3L)	//BW or Grayscale
+	||  (this->cl_iip_ro90.get_l_channels() == 3L &&//RGB & SW is ON
+	     cl_gts_gui.chkbtn_level_rgb_full_save_sw->value()
 	    )
 	) {
 	 /* スキャン画像保存 */
@@ -102,8 +102,8 @@ int gts_master::next_scan_and_save_( void )
 
 	/*------------------------------------------------*/
 	/* 07 RGB画像でトレス画像保存SWがONの場合 */
-	if (	(this->cl_iip_ro90.get_l_channels() == 3L) &&
-		(cl_gts_gui.chkbtn_level_rgb_trace_save_sw->value() == 1)
+	if (	(this->cl_iip_ro90.get_l_channels() == 3L)
+	&&	cl_gts_gui.chkbtn_level_rgb_trace_save_sw->value()
 	) {
 
 	 /* ２値化処理の準備 */
@@ -195,8 +195,8 @@ void gts_master::cb_scan_and_save_start( void )
 
 	/* 最初に番号が選択がない/設定できない */
 	if (this->cl_file_number_list.get_crnt_file_num() < 1) {
-		if (cl_gts_gui.choice_level_continue_type->value() == 
-		 cl_gts_master.cl_file_number_list.get_end_type_value()
+		if (cl_gts_gui.choice_level_continue_type->value()
+		== cl_gts_master.cl_file_number_list.get_end_type_value()
 		) {/*End*/
 			fl_alert("Select number!");
 		}

--- a/sources/libcpp83gts_callback_and_action/dogascan_event.cpp
+++ b/sources/libcpp83gts_callback_and_action/dogascan_event.cpp
@@ -220,7 +220,7 @@ void gts_master::_move_start( void )
 	this->cl_ogl_view.drag_move_start();
 
 	/* リアルタイムスイッチが入っているときに */
-	if (1 == cl_gts_gui.menite_color_trace_real_time->value()) {
+	if (cl_gts_gui.menite_color_trace_real_time->value()) {
 		iip_canvas *clp_sub;
 		clp_sub = this->cl_ogl_view.get_clp_sub_canvas();
 		/* sub画像がある(２画面表示)なら画面を白クリア */

--- a/sources/libcpp83gts_callback_and_action/gts_gui.cpp
+++ b/sources/libcpp83gts_callback_and_action/gts_gui.cpp
@@ -22,9 +22,9 @@ void gts_gui::cb_menite_level_i(Fl_Menu_*, void*) {
   if (cl_gts_gui.menite_level->value()) {
     cl_gts_master.cl_bro_level.cb_level_name();
     cl_gts_gui.window_opengl->show();/* Need for Minimize */
-    cl_gts_gui.window_level->show();
+    cl_gts_gui.window_level_set->show();
 } else {
-    cl_gts_gui.window_level->hide();
+    cl_gts_gui.window_level_set->hide();
 };
 }
 void gts_gui::cb_menite_level(Fl_Menu_* o, void* v) {
@@ -519,62 +519,131 @@ void gts_gui::cb_button_stop_scan(Fl_Button* o, void* v) {
   ((gts_gui*)(o->parent()->user_data()))->cb_button_stop_scan_i(o,v);
 }
 
-void gts_gui::cb_window_level_i(Fl_Double_Window*, void*) {
-  cl_gts_master.cl_bro_level.cb_cancel();
+void gts_gui::cb_window_level_set_i(Fl_Double_Window*, void*) {
+  cl_gts_gui.window_level_set->hide();
+cl_gts_gui.menite_level->clear();
 }
-void gts_gui::cb_window_level(Fl_Double_Window* o, void* v) {
-  ((gts_gui*)(o->user_data()))->cb_window_level_i(o,v);
+void gts_gui::cb_window_level_set(Fl_Double_Window* o, void* v) {
+  ((gts_gui*)(o->user_data()))->cb_window_level_set_i(o,v);
 }
 
-void gts_gui::cb__i(Fl_Button*, void*) {
-  cl_gts_master.cl_bro_level.cb_dir_up();
+void gts_gui::cb_Browse_i(Fl_Button*, void*) {
+  cl_gts_gui.window_level_browse->show();
 }
-void gts_gui::cb_(Fl_Button* o, void* v) {
-  ((gts_gui*)(o->parent()->user_data()))->cb__i(o,v);
+void gts_gui::cb_Browse(Fl_Button* o, void* v) {
+  ((gts_gui*)(o->parent()->parent()->user_data()))->cb_Browse_i(o,v);
 }
 
 void gts_gui::cb_filinp_level_dir_i(Fl_File_Input*, void*) {
   cl_gts_master.cl_bro_level.cb_dir();
 }
 void gts_gui::cb_filinp_level_dir(Fl_File_Input* o, void* v) {
-  ((gts_gui*)(o->parent()->user_data()))->cb_filinp_level_dir_i(o,v);
+  ((gts_gui*)(o->parent()->parent()->parent()->parent()->user_data()))->cb_filinp_level_dir_i(o,v);
 }
 
-void gts_gui::cb_choice_level_list_form_i(Fl_Choice*, void*) {
-  cl_gts_master.cl_bro_level.cb_file_or_level();
+void gts_gui::cb_strinp_level_file_i(Fl_Input*, void*) {
+  cl_gts_master.cl_bro_level.cb_level_name();
 }
-void gts_gui::cb_choice_level_list_form(Fl_Choice* o, void* v) {
-  ((gts_gui*)(o->parent()->parent()->user_data()))->cb_choice_level_list_form_i(o,v);
+void gts_gui::cb_strinp_level_file(Fl_Input* o, void* v) {
+  ((gts_gui*)(o->parent()->parent()->parent()->parent()->user_data()))->cb_strinp_level_file_i(o,v);
 }
 
-Fl_Menu_Item gts_gui::menu_choice_level_list_form[] = {
- {"File", 0,  0, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
- {"Level", 0,  0, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
+void gts_gui::cb_choice_level_continue_type_i(Fl_Choice* o, void*) {
+  if (o->value() == 0) {
+ cl_gts_gui.valinp_level_end->show();
+ cl_gts_gui.choice_level_endless_direction->hide();
+} else {
+ cl_gts_gui.valinp_level_end->hide();
+ cl_gts_gui.choice_level_endless_direction->show();
+};
+}
+void gts_gui::cb_choice_level_continue_type(Fl_Choice* o, void* v) {
+  ((gts_gui*)(o->parent()->parent()->parent()->parent()->user_data()))->cb_choice_level_continue_type_i(o,v);
+}
+
+Fl_Menu_Item gts_gui::menu_choice_level_continue_type[] = {
+ {"End", 0,  0, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
+ {"Endless", 0,  0, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
  {0,0,0,0,0,0,0,0,0}
 };
 
-void gts_gui::cb_Makedir_i(Fl_Button*, void*) {
+Fl_Menu_Item gts_gui::menu_choice_level_endless_direction[] = {
+ {"+1", 0,  0, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
+ {"-1", 0,  0, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
+ {0,0,0,0,0,0,0,0,0}
+};
+
+void gts_gui::cb_choice_level_image_file_format_i(Fl_Choice*, void*) {
+  cl_gts_master.cl_bro_level.cb_set_image_file_extension();
+}
+void gts_gui::cb_choice_level_image_file_format(Fl_Choice* o, void* v) {
+  ((gts_gui*)(o->parent()->parent()->parent()->parent()->user_data()))->cb_choice_level_image_file_format_i(o,v);
+}
+
+Fl_Menu_Item gts_gui::menu_choice_level_image_file_format[] = {
+ {"TIFF(*.tif)", 0,  0, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
+ {"TGA(*.tga)", 0,  0, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
+ {0,0,0,0,0,0,0,0,0}
+};
+
+void gts_gui::cb_Set_i(Fl_Button*, void*) {
+  cl_gts_master.cl_bro_level.cb_ok();
+}
+void gts_gui::cb_Set(Fl_Button* o, void* v) {
+  ((gts_gui*)(o->parent()->parent()->user_data()))->cb_Set_i(o,v);
+}
+
+void gts_gui::cb_filinp_level_rgb_scan_dir_i(Fl_File_Input*, void*) {
+  cl_gts_master.cl_bro_level.cb_rgb_scan_dir();
+}
+void gts_gui::cb_filinp_level_rgb_scan_dir(Fl_File_Input* o, void* v) {
+  ((gts_gui*)(o->parent()->parent()->parent()->parent()->parent()->user_data()))->cb_filinp_level_rgb_scan_dir_i(o,v);
+}
+
+void gts_gui::cb_ligbut_level_rgb_scan_browse_sw_i(Fl_Button*, void*) {
+  cl_gts_master.cl_bro_level.cb_browse_sw();
+cl_gts_gui.window_level_browse->show();
+}
+void gts_gui::cb_ligbut_level_rgb_scan_browse_sw(Fl_Button* o, void* v) {
+  ((gts_gui*)(o->parent()->parent()->parent()->parent()->parent()->user_data()))->cb_ligbut_level_rgb_scan_browse_sw_i(o,v);
+}
+
+void gts_gui::cb_chkbtn_color_trace_erase_1dot_i(Fl_Check_Button*, void*) {
+  cl_gts_master.cb_real_time_on_off();
+}
+void gts_gui::cb_chkbtn_color_trace_erase_1dot(Fl_Check_Button* o, void* v) {
+  ((gts_gui*)(o->parent()->parent()->user_data()))->cb_chkbtn_color_trace_erase_1dot_i(o,v);
+}
+
+void gts_gui::cb_window_level_browse_i(Fl_Double_Window*, void*) {
+  cl_gts_master.cl_bro_level.cb_cancel();
+}
+void gts_gui::cb_window_level_browse(Fl_Double_Window* o, void* v) {
+  ((gts_gui*)(o->user_data()))->cb_window_level_browse_i(o,v);
+}
+
+void gts_gui::cb_Make_i(Fl_Menu_*, void*) {
   cl_gts_master.cl_bro_level.cb_mkdir();
 }
-void gts_gui::cb_Makedir(Fl_Button* o, void* v) {
-  ((gts_gui*)(o->parent()->parent()->user_data()))->cb_Makedir_i(o,v);
+void gts_gui::cb_Make(Fl_Menu_* o, void* v) {
+  ((gts_gui*)(o->parent()->user_data()))->cb_Make_i(o,v);
 }
 
-void gts_gui::cb_Rename_i(Fl_Button*, void*) {
+void gts_gui::cb_Rename_i(Fl_Menu_*, void*) {
   cl_gts_master.cl_bro_level.cb_rename();
 }
-void gts_gui::cb_Rename(Fl_Button* o, void* v) {
-  ((gts_gui*)(o->parent()->parent()->user_data()))->cb_Rename_i(o,v);
+void gts_gui::cb_Rename(Fl_Menu_* o, void* v) {
+  ((gts_gui*)(o->parent()->user_data()))->cb_Rename_i(o,v);
 }
 
-void gts_gui::cb_button_level_shift_number_i(Fl_Button*, void*) {
+void gts_gui::cb_button_level_shift_number_i(Fl_Menu_*, void*) {
   cl_gts_master.cl_bro_level.cb_renumber();
 }
-void gts_gui::cb_button_level_shift_number(Fl_Button* o, void* v) {
-  ((gts_gui*)(o->parent()->parent()->user_data()))->cb_button_level_shift_number_i(o,v);
+void gts_gui::cb_button_level_shift_number(Fl_Menu_* o, void* v) {
+  ((gts_gui*)(o->parent()->user_data()))->cb_button_level_shift_number_i(o,v);
 }
 
-void gts_gui::cb_Explorer_i(Fl_Button*, void*) {
+void gts_gui::cb_Explorer_i(Fl_Menu_*, void*) {
   std::string comm("C:\\WINDOWS\\explorer.exe");
 # ifdef _WIN32
     comm += ' ';
@@ -599,9 +668,69 @@ void gts_gui::cb_Explorer_i(Fl_Button*, void*) {
     ::CloseHandle(pi.hThread);
 # endif
 }
-void gts_gui::cb_Explorer(Fl_Button* o, void* v) {
-  ((gts_gui*)(o->parent()->parent()->user_data()))->cb_Explorer_i(o,v);
+void gts_gui::cb_Explorer(Fl_Menu_* o, void* v) {
+  ((gts_gui*)(o->parent()->user_data()))->cb_Explorer_i(o,v);
 }
+
+void gts_gui::cb_ligbut_level_view_sw_i(Fl_Menu_*, void*) {
+  cl_gts_master.cl_bro_level.cb_info_redisplay();
+}
+void gts_gui::cb_ligbut_level_view_sw(Fl_Menu_* o, void* v) {
+  ((gts_gui*)(o->parent()->user_data()))->cb_ligbut_level_view_sw_i(o,v);
+}
+
+void gts_gui::cb_ligbut_level_info_rgb_sub_sw_i(Fl_Menu_*, void*) {
+  cl_gts_master.cl_bro_level.cb_info_redisplay();
+}
+void gts_gui::cb_ligbut_level_info_rgb_sub_sw(Fl_Menu_* o, void* v) {
+  ((gts_gui*)(o->parent()->user_data()))->cb_ligbut_level_info_rgb_sub_sw_i(o,v);
+}
+
+void gts_gui::cb_ligbut_level_image_x1_sw_i(Fl_Menu_*, void*) {
+  cl_gts_master.cl_bro_level.cb_x1view_wintgl();
+}
+void gts_gui::cb_ligbut_level_image_x1_sw(Fl_Menu_* o, void* v) {
+  ((gts_gui*)(o->parent()->user_data()))->cb_ligbut_level_image_x1_sw_i(o,v);
+}
+
+Fl_Menu_Item gts_gui::menu_1[] = {
+ {"File", 0,  0, 0, 64, FL_NORMAL_LABEL, 0, 14, 0},
+ {"Make Directory...", 0,  (Fl_Callback*)gts_gui::cb_Make, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
+ {"Rename...", 0,  (Fl_Callback*)gts_gui::cb_Rename, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
+ {"Shift Number...", 0,  (Fl_Callback*)gts_gui::cb_button_level_shift_number, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
+ {"Explorer...", 0,  (Fl_Callback*)gts_gui::cb_Explorer, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
+ {0,0,0,0,0,0,0,0,0},
+ {"View", 0,  0, 0, 64, FL_NORMAL_LABEL, 0, 14, 0},
+ {"Image", 0,  (Fl_Callback*)gts_gui::cb_ligbut_level_view_sw, 0, 6, FL_NORMAL_LABEL, 0, 14, 0},
+ {"_full", 0,  (Fl_Callback*)gts_gui::cb_ligbut_level_info_rgb_sub_sw, 0, 2, FL_NORMAL_LABEL, 0, 14, 0},
+ {"X1", 0,  (Fl_Callback*)gts_gui::cb_ligbut_level_image_x1_sw, 0, 18, FL_NORMAL_LABEL, 0, 14, 0},
+ {0,0,0,0,0,0,0,0,0},
+ {0,0,0,0,0,0,0,0,0}
+};
+Fl_Menu_Item* gts_gui::button_level_shift_number = gts_gui::menu_1 + 3;
+Fl_Menu_Item* gts_gui::ligbut_level_view_sw = gts_gui::menu_1 + 7;
+Fl_Menu_Item* gts_gui::ligbut_level_info_rgb_sub_sw = gts_gui::menu_1 + 8;
+Fl_Menu_Item* gts_gui::ligbut_level_image_x1_sw = gts_gui::menu_1 + 9;
+
+void gts_gui::cb__i(Fl_Button*, void*) {
+  cl_gts_master.cl_bro_level.cb_dir_up();
+}
+void gts_gui::cb_(Fl_Button* o, void* v) {
+  ((gts_gui*)(o->parent()->parent()->user_data()))->cb__i(o,v);
+}
+
+void gts_gui::cb_choice_level_list_form_i(Fl_Choice*, void*) {
+  cl_gts_master.cl_bro_level.cb_file_or_level();
+}
+void gts_gui::cb_choice_level_list_form(Fl_Choice* o, void* v) {
+  ((gts_gui*)(o->parent()->parent()->user_data()))->cb_choice_level_list_form_i(o,v);
+}
+
+Fl_Menu_Item gts_gui::menu_choice_level_list_form[] = {
+ {"File", 0,  0, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
+ {"Level", 0,  0, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
+ {0,0,0,0,0,0,0,0,0}
+};
 
 void gts_gui::cb_selbro_level_list_i(Fl_Browser*, void*) {
   cl_gts_master.cl_bro_level.cb_list();
@@ -630,91 +759,11 @@ void gts_gui::cb_valinp_level_crnt(Fl_Value_Input* o, void* v) {
   ((gts_gui*)(o->parent()->parent()->parent()->parent()->user_data()))->cb_valinp_level_crnt_i(o,v);
 }
 
-void gts_gui::cb_strinp_level_file_i(Fl_Input*, void*) {
-  cl_gts_master.cl_bro_level.cb_level_name();
-}
-void gts_gui::cb_strinp_level_file(Fl_Input* o, void* v) {
-  ((gts_gui*)(o->parent()->parent()->user_data()))->cb_strinp_level_file_i(o,v);
-}
-
-void gts_gui::cb_ligbut_level_image_x1_sw_i(Fl_Light_Button*, void*) {
-  cl_gts_master.cl_bro_level.cb_x1view_wintgl();
-}
-void gts_gui::cb_ligbut_level_image_x1_sw(Fl_Light_Button* o, void* v) {
-  ((gts_gui*)(o->parent()->parent()->user_data()))->cb_ligbut_level_image_x1_sw_i(o,v);
-}
-
-void gts_gui::cb_ligbut_level_view_sw_i(Fl_Light_Button*, void*) {
-  cl_gts_master.cl_bro_level.cb_info_redisplay();
-}
-void gts_gui::cb_ligbut_level_view_sw(Fl_Light_Button* o, void* v) {
-  ((gts_gui*)(o->parent()->parent()->user_data()))->cb_ligbut_level_view_sw_i(o,v);
-}
-
-void gts_gui::cb_choice_level_continue_type_i(Fl_Choice* o, void*) {
-  if (o->value() == 0) {
- cl_gts_gui.valinp_level_end->show();
- cl_gts_gui.choice_level_endless_direction->hide();
-} else {
- cl_gts_gui.valinp_level_end->hide();
- cl_gts_gui.choice_level_endless_direction->show();
-};
-}
-void gts_gui::cb_choice_level_continue_type(Fl_Choice* o, void* v) {
-  ((gts_gui*)(o->parent()->parent()->user_data()))->cb_choice_level_continue_type_i(o,v);
-}
-
-Fl_Menu_Item gts_gui::menu_choice_level_continue_type[] = {
- {"End", 0,  0, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
- {"Endless", 0,  0, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
- {0,0,0,0,0,0,0,0,0}
-};
-
-Fl_Menu_Item gts_gui::menu_choice_level_endless_direction[] = {
- {"+1", 0,  0, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
- {"-1", 0,  0, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
- {0,0,0,0,0,0,0,0,0}
-};
-
-void gts_gui::cb_choice_level_image_file_format_i(Fl_Choice*, void*) {
-  cl_gts_master.cl_bro_level.cb_set_image_file_extension();
-}
-void gts_gui::cb_choice_level_image_file_format(Fl_Choice* o, void* v) {
-  ((gts_gui*)(o->parent()->parent()->user_data()))->cb_choice_level_image_file_format_i(o,v);
-}
-
-Fl_Menu_Item gts_gui::menu_choice_level_image_file_format[] = {
- {"TIFF", 0,  0, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
- {"TGA", 0,  0, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
- {0,0,0,0,0,0,0,0,0}
-};
-
-void gts_gui::cb_filinp_level_rgb_scan_dir_i(Fl_File_Input*, void*) {
-  cl_gts_master.cl_bro_level.cb_rgb_scan_dir();
-}
-void gts_gui::cb_filinp_level_rgb_scan_dir(Fl_File_Input* o, void* v) {
-  ((gts_gui*)(o->parent()->parent()->user_data()))->cb_filinp_level_rgb_scan_dir_i(o,v);
-}
-
-void gts_gui::cb_ligbut_level_rgb_scan_browse_sw_i(Fl_Light_Button*, void*) {
-  cl_gts_master.cl_bro_level.cb_browse_sw();
-}
-void gts_gui::cb_ligbut_level_rgb_scan_browse_sw(Fl_Light_Button* o, void* v) {
-  ((gts_gui*)(o->parent()->parent()->user_data()))->cb_ligbut_level_rgb_scan_browse_sw_i(o,v);
-}
-
-void gts_gui::cb_ligbut_level_info_rgb_sub_sw_i(Fl_Light_Button*, void*) {
-  cl_gts_master.cl_bro_level.cb_info_redisplay();
-}
-void gts_gui::cb_ligbut_level_info_rgb_sub_sw(Fl_Light_Button* o, void* v) {
-  ((gts_gui*)(o->parent()->parent()->user_data()))->cb_ligbut_level_info_rgb_sub_sw_i(o,v);
-}
-
-void gts_gui::cb_OK_i(Fl_Button*, void*) {
+void gts_gui::cb_Set1_i(Fl_Button*, void*) {
   cl_gts_master.cl_bro_level.cb_ok();
 }
-void gts_gui::cb_OK(Fl_Button* o, void* v) {
-  ((gts_gui*)(o->parent()->parent()->user_data()))->cb_OK_i(o,v);
+void gts_gui::cb_Set1(Fl_Button* o, void* v) {
+  ((gts_gui*)(o->parent()->parent()->user_data()))->cb_Set1_i(o,v);
 }
 
 void gts_gui::cb_Cancel_i(Fl_Button*, void*) {
@@ -1914,11 +1963,11 @@ void gts_gui::cb_button_color_trace_06_src(Fl_Button* o, void* v) {
   ((gts_gui*)(o->parent()->parent()->parent()->user_data()))->cb_button_color_trace_06_src_i(o,v);
 }
 
-void gts_gui::cb_chkbtn_color_trace_erase_1dot_i(Fl_Check_Button*, void*) {
+void gts_gui::cb_chkbtn_color_trace_erase_1dot___i(Fl_Check_Button*, void*) {
   cl_gts_master.cb_real_time_on_off();
 }
-void gts_gui::cb_chkbtn_color_trace_erase_1dot(Fl_Check_Button* o, void* v) {
-  ((gts_gui*)(o->parent()->user_data()))->cb_chkbtn_color_trace_erase_1dot_i(o,v);
+void gts_gui::cb_chkbtn_color_trace_erase_1dot__(Fl_Check_Button* o, void* v) {
+  ((gts_gui*)(o->parent()->user_data()))->cb_chkbtn_color_trace_erase_1dot___i(o,v);
 }
 
 void gts_gui::cb_menite_color_trace_real_time___i(Fl_Check_Button*, void*) {
@@ -1971,7 +2020,7 @@ void gts_gui::cb_Delete(Fl_Menu_* o, void* v) {
   ((gts_gui*)(o->parent()->user_data()))->cb_Delete_i(o,v);
 }
 
-Fl_Menu_Item gts_gui::menu_1[] = {
+Fl_Menu_Item gts_gui::menu_2[] = {
  {"Edit", 0,  0, 0, 64, FL_NORMAL_LABEL, 0, 14, 0},
  {"Select All", 0x40061,  (Fl_Callback*)gts_gui::cb_Select, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
  {"Delete", 0x40078,  (Fl_Callback*)gts_gui::cb_Delete, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
@@ -2043,7 +2092,7 @@ void gts_gui::cb_Delete1(Fl_Menu_* o, void* v) {
   ((gts_gui*)(o->parent()->user_data()))->cb_Delete1_i(o,v);
 }
 
-Fl_Menu_Item gts_gui::menu_2[] = {
+Fl_Menu_Item gts_gui::menu_3[] = {
  {"Edit", 0,  0, 0, 64, FL_NORMAL_LABEL, 0, 14, 0},
  {"Add", 0x40073,  (Fl_Callback*)gts_gui::cb_Add, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
  {"All Add", 0x50073,  (Fl_Callback*)gts_gui::cb_All3, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
@@ -2435,7 +2484,7 @@ void gts_gui::cb_menite_limit_bb(Fl_Menu_* o, void* v) {
   ((gts_gui*)(o->parent()->user_data()))->cb_menite_limit_bb_i(o,v);
 }
 
-Fl_Menu_Item gts_gui::menu_3[] = {
+Fl_Menu_Item gts_gui::menu_4[] = {
  {"Histogram Limit", 0,  0, 0, 64, FL_NORMAL_LABEL, 0, 14, 0},
  {"No Limit", 0,  (Fl_Callback*)gts_gui::cb_menite_limit_nothing, 0, 12, FL_NORMAL_LABEL, 0, 14, 0},
  {"Hue", 0,  (Fl_Callback*)gts_gui::cb_menite_limit_hh, 0, 8, FL_NORMAL_LABEL, 0, 14, 0},
@@ -2444,10 +2493,10 @@ Fl_Menu_Item gts_gui::menu_3[] = {
  {0,0,0,0,0,0,0,0,0},
  {0,0,0,0,0,0,0,0,0}
 };
-Fl_Menu_Item* gts_gui::menite_limit_nothing = gts_gui::menu_3 + 1;
-Fl_Menu_Item* gts_gui::menite_limit_hh = gts_gui::menu_3 + 2;
-Fl_Menu_Item* gts_gui::menite_limit_aa = gts_gui::menu_3 + 3;
-Fl_Menu_Item* gts_gui::menite_limit_bb = gts_gui::menu_3 + 4;
+Fl_Menu_Item* gts_gui::menite_limit_nothing = gts_gui::menu_4 + 1;
+Fl_Menu_Item* gts_gui::menite_limit_hh = gts_gui::menu_4 + 2;
+Fl_Menu_Item* gts_gui::menite_limit_aa = gts_gui::menu_4 + 3;
+Fl_Menu_Item* gts_gui::menite_limit_bb = gts_gui::menu_4 + 4;
 
 static const unsigned char idata_color_belt1000x10hue[] =
 {255,0,0,255,0,0,255,1,0,255,2,0,255,2,0,255,3,0,255,4,0,255,4,0,255,7,0,
@@ -5252,75 +5301,185 @@ Fl_Double_Window* gts_gui::make_window() {
     window_next_scan->set_modal();
     window_next_scan->end();
   } // Fl_Double_Window* window_next_scan
-  { window_level = new Fl_Double_Window(380, 630, "Browse Level");
-    window_level->callback((Fl_Callback*)cb_window_level, (void*)(this));
-    { Fl_Button* o = new Fl_Button(0, 0, 0, 0);
-      o->shortcut(0x40075);
-      o->callback((Fl_Callback*)cb_);
-    } // Fl_Button* o
-    { filinp_level_dir = new Fl_File_Input(0, 20, 380, 35, "Directory");
-      filinp_level_dir->box(FL_BORDER_BOX);
-      filinp_level_dir->callback((Fl_Callback*)cb_filinp_level_dir);
-      filinp_level_dir->align(Fl_Align(FL_ALIGN_TOP_LEFT));
-      filinp_level_dir->when(FL_WHEN_CHANGED);
-    } // Fl_File_Input* filinp_level_dir
-    { Fl_Group* o = new Fl_Group(0, 60, 380, 25);
-      { choice_level_list_form = new Fl_Choice(5, 60, 80, 25);
+  { window_level_set = new Fl_Double_Window(200, 430, "Level");
+    window_level_set->callback((Fl_Callback*)cb_window_level_set, (void*)(this));
+    { Fl_Group* o = new Fl_Group(0, 0, 385, 240);
+      o->box(FL_BORDER_BOX);
+      { Fl_Button* o = new Fl_Button(115, 5, 80, 25, "Browse...");
+        o->callback((Fl_Callback*)cb_Browse);
+      } // Fl_Button* o
+      { Fl_Group* o = new Fl_Group(0, 35, 385, 175);
+        { Fl_Group* o = new Fl_Group(0, 35, 200, 50);
+          { filinp_level_dir = new Fl_File_Input(0, 50, 200, 35, "Directory");
+            filinp_level_dir->box(FL_BORDER_BOX);
+            filinp_level_dir->callback((Fl_Callback*)cb_filinp_level_dir);
+            filinp_level_dir->align(Fl_Align(FL_ALIGN_TOP_LEFT));
+            filinp_level_dir->when(FL_WHEN_CHANGED);
+          } // Fl_File_Input* filinp_level_dir
+          o->end();
+        } // Fl_Group* o
+        { Fl_Group* o = new Fl_Group(0, 85, 200, 30);
+          { new Fl_Box(0, 90, 80, 25);
+          } // Fl_Box* o
+          { strinp_level_file = new Fl_Input(80, 90, 120, 25, "Level");
+            strinp_level_file->box(FL_BORDER_BOX);
+            strinp_level_file->callback((Fl_Callback*)cb_strinp_level_file);
+            strinp_level_file->when(FL_WHEN_CHANGED);
+          } // Fl_Input* strinp_level_file
+          o->end();
+        } // Fl_Group* o
+        { Fl_Group* o = new Fl_Group(0, 115, 200, 30);
+          { new Fl_Box(0, 120, 80, 25);
+          } // Fl_Box* o
+          { valinp_level_start = new Fl_Value_Input(80, 120, 50, 25, "Start");
+            valinp_level_start->box(FL_BORDER_BOX);
+            valinp_level_start->minimum(1);
+            valinp_level_start->maximum(9999);
+            valinp_level_start->value(1);
+          } // Fl_Value_Input* valinp_level_start
+          { new Fl_Box(130, 120, 70, 25);
+          } // Fl_Box* o
+          o->end();
+        } // Fl_Group* o
+        { Fl_Group* o = new Fl_Group(0, 150, 200, 25);
+          { choice_level_continue_type = new Fl_Choice(0, 150, 80, 25);
+            choice_level_continue_type->down_box(FL_BORDER_BOX);
+            choice_level_continue_type->callback((Fl_Callback*)cb_choice_level_continue_type);
+            choice_level_continue_type->menu(menu_choice_level_continue_type);
+          } // Fl_Choice* choice_level_continue_type
+          { choice_level_endless_direction = new Fl_Choice(80, 150, 50, 25);
+            choice_level_endless_direction->down_box(FL_BORDER_BOX);
+            choice_level_endless_direction->menu(menu_choice_level_endless_direction);
+          } // Fl_Choice* choice_level_endless_direction
+          { valinp_level_end = new Fl_Value_Input(80, 150, 50, 25);
+            valinp_level_end->box(FL_BORDER_BOX);
+            valinp_level_end->minimum(1);
+            valinp_level_end->maximum(9999);
+            valinp_level_end->value(1);
+          } // Fl_Value_Input* valinp_level_end
+          { new Fl_Box(130, 150, 70, 25);
+          } // Fl_Box* o
+          o->end();
+        } // Fl_Group* o
+        { Fl_Group* o = new Fl_Group(0, 175, 200, 30);
+          { new Fl_Box(0, 180, 80, 25);
+          } // Fl_Box* o
+          { choice_level_image_file_format = new Fl_Choice(80, 180, 100, 25, "Format");
+            choice_level_image_file_format->down_box(FL_BORDER_BOX);
+            choice_level_image_file_format->callback((Fl_Callback*)cb_choice_level_image_file_format);
+            choice_level_image_file_format->menu(menu_choice_level_image_file_format);
+          } // Fl_Choice* choice_level_image_file_format
+          { new Fl_Box(180, 180, 20, 25);
+          } // Fl_Box* o
+          o->end();
+        } // Fl_Group* o
+        o->end();
+      } // Fl_Group* o
+      { Fl_Button* o = new Fl_Button(5, 210, 80, 25, "Set Number");
+        o->callback((Fl_Callback*)cb_Set);
+      } // Fl_Button* o
+      o->end();
+    } // Fl_Group* o
+    { Fl_Group* o = new Fl_Group(0, 245, 200, 140, "Save RGB");
+      o->box(FL_BORDER_BOX);
+      o->align(Fl_Align(FL_ALIGN_TOP_LEFT|FL_ALIGN_INSIDE));
+      { chkbtn_level_rgb_trace_save_sw = new Fl_Check_Button(5, 265, 190, 20, "Save Trace Image");
+        chkbtn_level_rgb_trace_save_sw->down_box(FL_DOWN_BOX);
+      } // Fl_Check_Button* chkbtn_level_rgb_trace_save_sw
+      { Fl_Group* o = new Fl_Group(5, 285, 190, 100);
+        { chkbtn_level_rgb_full_save_sw = new Fl_Check_Button(5, 285, 190, 20, "Save Scan Image");
+          chkbtn_level_rgb_full_save_sw->down_box(FL_DOWN_BOX);
+          chkbtn_level_rgb_full_save_sw->value(1);
+        } // Fl_Check_Button* chkbtn_level_rgb_full_save_sw
+        { Fl_Group* o = new Fl_Group(10, 305, 180, 75);
+          o->box(FL_BORDER_BOX);
+          { Fl_Group* o = new Fl_Group(15, 305, 170, 55);
+            { filinp_level_rgb_scan_dir = new Fl_File_Input(15, 320, 155, 35, "Directory");
+              filinp_level_rgb_scan_dir->callback((Fl_Callback*)cb_filinp_level_rgb_scan_dir);
+              filinp_level_rgb_scan_dir->align(Fl_Align(FL_ALIGN_TOP_LEFT));
+              filinp_level_rgb_scan_dir->when(FL_WHEN_CHANGED);
+            } // Fl_File_Input* filinp_level_rgb_scan_dir
+            { ligbut_level_rgb_scan_browse_sw = new Fl_Button(170, 330, 15, 25, "<");
+              ligbut_level_rgb_scan_browse_sw->type(1);
+              ligbut_level_rgb_scan_browse_sw->callback((Fl_Callback*)cb_ligbut_level_rgb_scan_browse_sw);
+            } // Fl_Button* ligbut_level_rgb_scan_browse_sw
+            o->end();
+          } // Fl_Group* o
+          { chkbtn_level_rgb_with_full_sw = new Fl_Check_Button(15, 360, 175, 20, "Add _full in level");
+            chkbtn_level_rgb_with_full_sw->down_box(FL_DOWN_BOX);
+            chkbtn_level_rgb_with_full_sw->value(1);
+          } // Fl_Check_Button* chkbtn_level_rgb_with_full_sw
+          o->end();
+        } // Fl_Group* o
+        o->end();
+      } // Fl_Group* o
+      o->end();
+    } // Fl_Group* o
+    { Fl_Group* o = new Fl_Group(0, 390, 200, 40, "Filter");
+      o->box(FL_BORDER_BOX);
+      o->align(Fl_Align(FL_ALIGN_TOP_LEFT|FL_ALIGN_INSIDE));
+      { chkbtn_color_trace_erase_1dot = new Fl_Check_Button(5, 405, 190, 25, "Erase dot noise");
+        chkbtn_color_trace_erase_1dot->down_box(FL_DOWN_BOX);
+        chkbtn_color_trace_erase_1dot->callback((Fl_Callback*)cb_chkbtn_color_trace_erase_1dot);
+      } // Fl_Check_Button* chkbtn_color_trace_erase_1dot
+      o->end();
+    } // Fl_Group* o
+    window_level_set->set_non_modal();
+    window_level_set->end();
+  } // Fl_Double_Window* window_level_set
+  { window_level_browse = new Fl_Double_Window(380, 425, "Browse");
+    window_level_browse->callback((Fl_Callback*)cb_window_level_browse, (void*)(this));
+    { Fl_Menu_Bar* o = new Fl_Menu_Bar(0, 0, 380, 25);
+      o->menu(menu_1);
+    } // Fl_Menu_Bar* o
+    { Fl_Group* o = new Fl_Group(0, 30, 380, 25);
+      { Fl_Button* o = new Fl_Button(5, 30, 15, 25, "<");
+        o->shortcut(0x40075);
+        o->callback((Fl_Callback*)cb_);
+      } // Fl_Button* o
+      { choice_level_list_form = new Fl_Choice(25, 30, 80, 25);
         choice_level_list_form->down_box(FL_BORDER_BOX);
         choice_level_list_form->callback((Fl_Callback*)cb_choice_level_list_form);
         choice_level_list_form->menu(menu_choice_level_list_form);
       } // Fl_Choice* choice_level_list_form
-      { Fl_Button* o = new Fl_Button(90, 60, 60, 25, "Makedir");
-        o->callback((Fl_Callback*)cb_Makedir);
-      } // Fl_Button* o
-      { Fl_Button* o = new Fl_Button(155, 60, 60, 25, "Rename");
-        o->callback((Fl_Callback*)cb_Rename);
-      } // Fl_Button* o
-      { button_level_shift_number = new Fl_Button(220, 60, 85, 25, "Shift number");
-        button_level_shift_number->callback((Fl_Callback*)cb_button_level_shift_number);
-        button_level_shift_number->hide();
-      } // Fl_Button* button_level_shift_number
-      { Fl_Box* o = new Fl_Box(305, 60, 10, 25);
+      { Fl_Box* o = new Fl_Box(105, 30, 275, 25);
         Fl_Group::current()->resizable(o);
       } // Fl_Box* o
-      { Fl_Button* o = new Fl_Button(315, 60, 60, 25, "Explorer");
-        o->callback((Fl_Callback*)cb_Explorer);
-      } // Fl_Button* o
       o->end();
     } // Fl_Group* o
-    { Fl_Tile* o = new Fl_Tile(0, 90, 380, 330);
+    { Fl_Tile* o = new Fl_Tile(0, 60, 380, 330);
       o->align(Fl_Align(FL_ALIGN_CENTER));
-      { Fl_Group* o = new Fl_Group(0, 90, 150, 330);
+      { Fl_Group* o = new Fl_Group(0, 60, 150, 330);
         o->box(FL_DOWN_BOX);
-        { selbro_level_list = new Fl_Browser(0, 90, 150, 330);
+        { selbro_level_list = new Fl_Browser(0, 60, 150, 330);
           selbro_level_list->type(2);
           selbro_level_list->callback((Fl_Callback*)cb_selbro_level_list);
           selbro_level_list->align(Fl_Align(FL_ALIGN_CENTER));
         } // Fl_Browser* selbro_level_list
         o->end();
       } // Fl_Group* o
-      { Fl_Group* o = new Fl_Group(150, 90, 230, 150);
+      { Fl_Group* o = new Fl_Group(150, 60, 230, 150);
         o->box(FL_DOWN_BOX);
-        { box_level_image = new Fl_Box(150, 90, 230, 150);
+        { box_level_image = new Fl_Box(150, 60, 230, 150);
         } // Fl_Box* box_level_image
         o->end();
       } // Fl_Group* o
-      { Fl_Group* o = new Fl_Group(150, 240, 230, 180);
+      { Fl_Group* o = new Fl_Group(150, 210, 230, 180);
         o->box(FL_DOWN_BOX);
-        { txtdis_level_info = new Fl_Text_Display(150, 240, 230, 155);
+        { txtdis_level_info = new Fl_Text_Display(150, 210, 230, 155);
           txtdis_level_info->color(FL_LIGHT1);
           txtdis_level_info->align(Fl_Align(FL_ALIGN_LEFT));
           Fl_Group::current()->resizable(txtdis_level_info);
         } // Fl_Text_Display* txtdis_level_info
-        { Fl_Group* o = new Fl_Group(150, 395, 230, 25);
-          { scroll_level_info_number = new Fl_Scrollbar(150, 395, 190, 25);
+        { Fl_Group* o = new Fl_Group(150, 365, 230, 25);
+          { scroll_level_info_number = new Fl_Scrollbar(150, 365, 190, 25);
             scroll_level_info_number->type(1);
             scroll_level_info_number->box(FL_BORDER_BOX);
             scroll_level_info_number->callback((Fl_Callback*)cb_scroll_level_info_number);
             scroll_level_info_number->when(FL_WHEN_RELEASE);
             Fl_Group::current()->resizable(scroll_level_info_number);
           } // Fl_Scrollbar* scroll_level_info_number
-          { valinp_level_crnt = new Fl_Value_Input(340, 395, 40, 25);
+          { valinp_level_crnt = new Fl_Value_Input(340, 365, 40, 25);
             valinp_level_crnt->minimum(1);
             valinp_level_crnt->maximum(9999);
             valinp_level_crnt->value(1);
@@ -5334,114 +5493,22 @@ Fl_Double_Window* gts_gui::make_window() {
       o->end();
       Fl_Group::current()->resizable(o);
     } // Fl_Tile* o
-    { Fl_Group* o = new Fl_Group(0, 425, 380, 25);
-      { new Fl_Box(0, 425, 80, 25);
-      } // Fl_Box* o
-      { strinp_level_file = new Fl_Input(80, 425, 300, 25, "Level");
-        strinp_level_file->box(FL_BORDER_BOX);
-        strinp_level_file->callback((Fl_Callback*)cb_strinp_level_file);
-        strinp_level_file->when(FL_WHEN_CHANGED);
-        Fl_Group::current()->resizable(strinp_level_file);
-      } // Fl_Input* strinp_level_file
-      o->end();
-    } // Fl_Group* o
-    { Fl_Group* o = new Fl_Group(0, 455, 380, 25);
-      { valinp_level_start = new Fl_Value_Input(80, 455, 50, 25, "Start");
-        valinp_level_start->box(FL_BORDER_BOX);
-        valinp_level_start->minimum(1);
-        valinp_level_start->maximum(9999);
-        valinp_level_start->value(1);
-      } // Fl_Value_Input* valinp_level_start
-      { Fl_Box* o = new Fl_Box(130, 455, 110, 25);
-        Fl_Group::current()->resizable(o);
-      } // Fl_Box* o
-      { ligbut_level_image_x1_sw = new Fl_Light_Button(240, 455, 35, 25, "x1");
-        ligbut_level_image_x1_sw->callback((Fl_Callback*)cb_ligbut_level_image_x1_sw);
-      } // Fl_Light_Button* ligbut_level_image_x1_sw
-      { ligbut_level_view_sw = new Fl_Light_Button(280, 455, 95, 25, "View image");
-        ligbut_level_view_sw->callback((Fl_Callback*)cb_ligbut_level_view_sw);
-      } // Fl_Light_Button* ligbut_level_view_sw
-      o->end();
-    } // Fl_Group* o
-    { Fl_Group* o = new Fl_Group(0, 485, 380, 25);
-      { choice_level_continue_type = new Fl_Choice(0, 485, 80, 25);
-        choice_level_continue_type->down_box(FL_BORDER_BOX);
-        choice_level_continue_type->callback((Fl_Callback*)cb_choice_level_continue_type);
-        choice_level_continue_type->menu(menu_choice_level_continue_type);
-      } // Fl_Choice* choice_level_continue_type
-      { choice_level_endless_direction = new Fl_Choice(80, 485, 50, 25);
-        choice_level_endless_direction->down_box(FL_BORDER_BOX);
-        choice_level_endless_direction->menu(menu_choice_level_endless_direction);
-      } // Fl_Choice* choice_level_endless_direction
-      { valinp_level_end = new Fl_Value_Input(80, 485, 50, 25);
-        valinp_level_end->box(FL_BORDER_BOX);
-        valinp_level_end->minimum(1);
-        valinp_level_end->maximum(9999);
-        valinp_level_end->value(1);
-      } // Fl_Value_Input* valinp_level_end
-      { Fl_Box* o = new Fl_Box(130, 485, 250, 25);
-        Fl_Group::current()->resizable(o);
-      } // Fl_Box* o
-      o->end();
-    } // Fl_Group* o
-    { Fl_Group* o = new Fl_Group(0, 515, 380, 25);
-      { choice_level_image_file_format = new Fl_Choice(80, 515, 65, 25, "Format");
-        choice_level_image_file_format->down_box(FL_BORDER_BOX);
-        choice_level_image_file_format->callback((Fl_Callback*)cb_choice_level_image_file_format);
-        choice_level_image_file_format->menu(menu_choice_level_image_file_format);
-      } // Fl_Choice* choice_level_image_file_format
-      { Fl_Box* o = new Fl_Box(145, 515, 235, 25);
-        Fl_Group::current()->resizable(o);
-      } // Fl_Box* o
-      o->end();
-    } // Fl_Group* o
-    { Fl_Group* o = new Fl_Group(0, 545, 380, 50);
-      { filinp_level_rgb_scan_dir = new Fl_File_Input(0, 560, 135, 35, "RGB scan dir");
-        filinp_level_rgb_scan_dir->callback((Fl_Callback*)cb_filinp_level_rgb_scan_dir);
-        filinp_level_rgb_scan_dir->align(Fl_Align(FL_ALIGN_TOP_LEFT));
-        filinp_level_rgb_scan_dir->when(FL_WHEN_CHANGED);
-        filinp_level_rgb_scan_dir->deactivate();
-        Fl_Group::current()->resizable(filinp_level_rgb_scan_dir);
-      } // Fl_File_Input* filinp_level_rgb_scan_dir
-      { chkbtn_level_rgb_trace_save_sw = new Fl_Check_Button(135, 575, 60, 20, "S.C.T.");
-        chkbtn_level_rgb_trace_save_sw->tooltip("Save Color Trace level");
-        chkbtn_level_rgb_trace_save_sw->down_box(FL_DOWN_BOX);
-      } // Fl_Check_Button* chkbtn_level_rgb_trace_save_sw
-      { chkbtn_level_rgb_full_save_sw = new Fl_Check_Button(195, 575, 60, 20, "S.Full");
-        chkbtn_level_rgb_full_save_sw->tooltip("Save RGB Full  level");
-        chkbtn_level_rgb_full_save_sw->down_box(FL_DOWN_BOX);
-        chkbtn_level_rgb_full_save_sw->value(1);
-      } // Fl_Check_Button* chkbtn_level_rgb_full_save_sw
-      { chkbtn_level_rgb_with_full_sw = new Fl_Check_Button(195, 553, 75, 20, "With_full");
-        chkbtn_level_rgb_with_full_sw->tooltip("With _full in RGB full name");
-        chkbtn_level_rgb_with_full_sw->down_box(FL_DOWN_BOX);
-        chkbtn_level_rgb_with_full_sw->value(1);
-      } // Fl_Check_Button* chkbtn_level_rgb_with_full_sw
-      { ligbut_level_rgb_scan_browse_sw = new Fl_Light_Button(255, 570, 70, 25, "Browse");
-        ligbut_level_rgb_scan_browse_sw->callback((Fl_Callback*)cb_ligbut_level_rgb_scan_browse_sw);
-      } // Fl_Light_Button* ligbut_level_rgb_scan_browse_sw
-      { ligbut_level_info_rgb_sub_sw = new Fl_Light_Button(325, 570, 50, 25, "Full");
-        ligbut_level_info_rgb_sub_sw->callback((Fl_Callback*)cb_ligbut_level_info_rgb_sub_sw);
-        ligbut_level_info_rgb_sub_sw->hide();
-      } // Fl_Light_Button* ligbut_level_info_rgb_sub_sw
-      o->end();
-    } // Fl_Group* o
-    { Fl_Group* o = new Fl_Group(0, 600, 380, 24);
-      { Fl_Button* o = new Fl_Button(10, 600, 80, 24, "OK");
-        o->callback((Fl_Callback*)cb_OK);
+    { Fl_Group* o = new Fl_Group(0, 395, 380, 24);
+      { Fl_Button* o = new Fl_Button(10, 395, 80, 24, "Set");
+        o->callback((Fl_Callback*)cb_Set1);
       } // Fl_Button* o
-      { Fl_Box* o = new Fl_Box(90, 600, 200, 24);
+      { Fl_Box* o = new Fl_Box(90, 395, 200, 24);
         Fl_Group::current()->resizable(o);
       } // Fl_Box* o
-      { Fl_Button* o = new Fl_Button(290, 600, 80, 24, "Cancel");
+      { Fl_Button* o = new Fl_Button(290, 395, 80, 24, "Cancel");
         o->callback((Fl_Callback*)cb_Cancel);
       } // Fl_Button* o
       o->end();
     } // Fl_Group* o
-    window_level->set_non_modal();
-    window_level->size_range(370, 300);
-    window_level->end();
-  } // Fl_Double_Window* window_level
+    window_level_browse->set_modal();
+    window_level_browse->size_range(180, 120, 1920, 1200);
+    window_level_browse->end();
+  } // Fl_Double_Window* window_level_browse
   { window_x1view = new Fl_Double_Window(300, 300, "x1");
     window_x1view->callback((Fl_Callback*)cb_window_x1view, (void*)(this));
     window_x1view->align(Fl_Align(FL_ALIGN_CENTER));
@@ -5911,7 +5978,7 @@ Fl_Double_Window* gts_gui::make_window() {
     window_pixel_type_and_bright->end();
     window_pixel_type_and_bright->resizable(window_pixel_type_and_bright);
   } // Fl_Double_Window* window_pixel_type_and_bright
-  { window_color_trace = new Fl_Double_Window(285, 785, "Color Trace Enhancement");
+  { window_color_trace = new Fl_Double_Window(285, 755, "Color Trace Enhancement");
     window_color_trace->callback((Fl_Callback*)cb_window_color_trace, (void*)(this));
     { Fl_Group* o = new Fl_Group(5, 5, 280, 120);
       { Fl_Text_Display* o = new Fl_Text_Display(5, 10, 0, 0, "1");
@@ -6609,10 +6676,11 @@ Fl_Double_Window* gts_gui::make_window() {
       } // Fl_Group* group_color_trace_06grp
       o->end();
     } // Fl_Group* o
-    { chkbtn_color_trace_erase_1dot = new Fl_Check_Button(5, 755, 130, 25, "Erase dot noise");
-      chkbtn_color_trace_erase_1dot->down_box(FL_DOWN_BOX);
-      chkbtn_color_trace_erase_1dot->callback((Fl_Callback*)cb_chkbtn_color_trace_erase_1dot);
-    } // Fl_Check_Button* chkbtn_color_trace_erase_1dot
+    { chkbtn_color_trace_erase_1dot__ = new Fl_Check_Button(5, 755, 130, 25, "Erase dot noise");
+      chkbtn_color_trace_erase_1dot__->down_box(FL_DOWN_BOX);
+      chkbtn_color_trace_erase_1dot__->callback((Fl_Callback*)cb_chkbtn_color_trace_erase_1dot__);
+      chkbtn_color_trace_erase_1dot__->hide();
+    } // Fl_Check_Button* chkbtn_color_trace_erase_1dot__
     { menite_color_trace_real_time__ = new Fl_Check_Button(15, 780, 90, 25, "Real Time");
       menite_color_trace_real_time__->down_box(FL_DOWN_BOX);
       menite_color_trace_real_time__->value(1);
@@ -6637,7 +6705,7 @@ Fl_Double_Window* gts_gui::make_window() {
   { window_fnum_list = new Fl_Double_Window(116, 350, "Number");
     window_fnum_list->callback((Fl_Callback*)cb_window_fnum_list, (void*)(this));
     { Fl_Menu_Bar* o = new Fl_Menu_Bar(0, 0, 116, 25);
-      o->menu(menu_1);
+      o->menu(menu_2);
     } // Fl_Menu_Bar* o
     { norinp_fnum_insert = new Fl_Input(0, 25, 116, 25);
       norinp_fnum_insert->box(FL_BORDER_BOX);
@@ -6662,7 +6730,7 @@ Fl_Double_Window* gts_gui::make_window() {
       o->callback((Fl_Callback*)cb_3);
     } // Fl_Button* o
     { Fl_Menu_Bar* o = new Fl_Menu_Bar(0, 0, 300, 25);
-      o->menu(menu_2);
+      o->menu(menu_3);
     } // Fl_Menu_Bar* o
     { filinp_trace_batch_dir = new Fl_File_Input(0, 40, 300, 35, "Directory");
       filinp_trace_batch_dir->box(FL_BORDER_BOX);
@@ -6977,7 +7045,7 @@ Fl_Double_Window* gts_gui::make_window() {
   { window_hab_histogram = new Fl_Double_Window(1000, 565, "Input Color(HSV Min Max)");
     window_hab_histogram->callback((Fl_Callback*)cb_window_hab_histogram, (void*)(this));
     { Fl_Menu_Bar* o = new Fl_Menu_Bar(0, 0, 1000, 25);
-      o->menu(menu_3);
+      o->menu(menu_4);
     } // Fl_Menu_Bar* o
     { Fl_Scroll* o = new Fl_Scroll(0, 25, 1000, 540);
       { Fl_Group* o = new Fl_Group(0, 25, 1000, 180);

--- a/sources/libcpp83gts_callback_and_action/gts_gui.cpp
+++ b/sources/libcpp83gts_callback_and_action/gts_gui.cpp
@@ -5427,7 +5427,7 @@ Fl_Double_Window* gts_gui::make_window() {
     window_level_set->set_non_modal();
     window_level_set->end();
   } // Fl_Double_Window* window_level_set
-  { window_level_browse = new Fl_Double_Window(380, 425, "Browse");
+  { window_level_browse = new Fl_Double_Window(380, 425, "Level Browse");
     window_level_browse->callback((Fl_Callback*)cb_window_level_browse, (void*)(this));
     { Fl_Menu_Bar* o = new Fl_Menu_Bar(0, 0, 380, 25);
       o->menu(menu_1);

--- a/sources/libcpp83gts_callback_and_action/gts_gui.cpp
+++ b/sources/libcpp83gts_callback_and_action/gts_gui.cpp
@@ -612,7 +612,7 @@ void gts_gui::cb_chkbtn_color_trace_erase_1dot_i(Fl_Check_Button*, void*) {
   cl_gts_master.cb_real_time_on_off();
 }
 void gts_gui::cb_chkbtn_color_trace_erase_1dot(Fl_Check_Button* o, void* v) {
-  ((gts_gui*)(o->parent()->parent()->user_data()))->cb_chkbtn_color_trace_erase_1dot_i(o,v);
+  ((gts_gui*)(o->parent()->parent()->parent()->user_data()))->cb_chkbtn_color_trace_erase_1dot_i(o,v);
 }
 
 void gts_gui::cb_window_level_browse_i(Fl_Double_Window*, void*) {
@@ -1119,11 +1119,11 @@ void gts_gui::cb_window_color_trace(Fl_Double_Window* o, void* v) {
 void gts_gui::cb_chkbtn_color_trace_01_chk_i(Fl_Check_Button* o, void*) {
   if (o->value()) {
     cl_gts_gui.group_color_trace_01grp->activate();
-    cl_gts_gui.chkbtn_thickness_01_chk->value(1);
+    cl_gts_gui.chkbtn_thickness_01_chk->set();
     cl_gts_gui.group_thickness_01grp->activate();
 } else {
     cl_gts_gui.group_color_trace_01grp->deactivate();
-    cl_gts_gui.chkbtn_thickness_01_chk->value(0);
+    cl_gts_gui.chkbtn_thickness_01_chk->clear();
     cl_gts_gui.group_thickness_01grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();
@@ -1396,11 +1396,11 @@ void gts_gui::cb_button_color_trace_01_src(Fl_Button* o, void* v) {
 void gts_gui::cb_chkbtn_color_trace_02_chk_i(Fl_Check_Button* o, void*) {
   if (o->value()) {
     cl_gts_gui.group_color_trace_02grp->activate();
-    cl_gts_gui.chkbtn_thickness_02_chk->value(1);
+    cl_gts_gui.chkbtn_thickness_02_chk->set();
     cl_gts_gui.group_thickness_02grp->activate();
 } else {
     cl_gts_gui.group_color_trace_02grp->deactivate();
-    cl_gts_gui.chkbtn_thickness_02_chk->value(0);
+    cl_gts_gui.chkbtn_thickness_02_chk->clear();
     cl_gts_gui.group_thickness_02grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();
@@ -1510,11 +1510,11 @@ void gts_gui::cb_button_color_trace_02_src(Fl_Button* o, void* v) {
 void gts_gui::cb_chkbtn_color_trace_03_chk_i(Fl_Check_Button* o, void*) {
   if (o->value()) {
     cl_gts_gui.group_color_trace_03grp->activate();
-    cl_gts_gui.chkbtn_thickness_03_chk->value(1);
+    cl_gts_gui.chkbtn_thickness_03_chk->set();
     cl_gts_gui.group_thickness_03grp->activate();
 } else {
     cl_gts_gui.group_color_trace_03grp->deactivate();
-    cl_gts_gui.chkbtn_thickness_03_chk->value(0);
+    cl_gts_gui.chkbtn_thickness_03_chk->clear();
     cl_gts_gui.group_thickness_03grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();
@@ -1624,11 +1624,11 @@ void gts_gui::cb_button_color_trace_03_src(Fl_Button* o, void* v) {
 void gts_gui::cb_chkbtn_color_trace_04_chk_i(Fl_Check_Button* o, void*) {
   if (o->value()) {
     cl_gts_gui.group_color_trace_04grp->activate();
-    cl_gts_gui.chkbtn_thickness_04_chk->value(1);
+    cl_gts_gui.chkbtn_thickness_04_chk->set();
     cl_gts_gui.group_thickness_04grp->activate();
 } else {
     cl_gts_gui.group_color_trace_04grp->deactivate();
-    cl_gts_gui.chkbtn_thickness_04_chk->value(0);
+    cl_gts_gui.chkbtn_thickness_04_chk->clear();
     cl_gts_gui.group_thickness_04grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();
@@ -1738,11 +1738,11 @@ void gts_gui::cb_button_color_trace_04_src(Fl_Button* o, void* v) {
 void gts_gui::cb_chkbtn_color_trace_05_chk_i(Fl_Check_Button* o, void*) {
   if (o->value()) {
     cl_gts_gui.group_color_trace_05grp->activate();
-    cl_gts_gui.chkbtn_thickness_05_chk->value(1);
+    cl_gts_gui.chkbtn_thickness_05_chk->set();
     cl_gts_gui.group_thickness_05grp->activate();
 } else {
     cl_gts_gui.group_color_trace_05grp->deactivate();
-    cl_gts_gui.chkbtn_thickness_05_chk->value(0);
+    cl_gts_gui.chkbtn_thickness_05_chk->clear();
     cl_gts_gui.group_thickness_05grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();
@@ -1852,11 +1852,11 @@ void gts_gui::cb_button_color_trace_05_src(Fl_Button* o, void* v) {
 void gts_gui::cb_chkbtn_color_trace_06_chk_i(Fl_Check_Button* o, void*) {
   if (o->value()) {
     cl_gts_gui.group_color_trace_06grp->activate();
-    cl_gts_gui.chkbtn_thickness_06_chk->value(1);
+    cl_gts_gui.chkbtn_thickness_06_chk->set();
     cl_gts_gui.group_thickness_06grp->activate();
 } else {
     cl_gts_gui.group_color_trace_06grp->deactivate();
-    cl_gts_gui.chkbtn_thickness_06_chk->value(0);
+    cl_gts_gui.chkbtn_thickness_06_chk->clear();
     cl_gts_gui.group_thickness_06grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();
@@ -2145,11 +2145,11 @@ void gts_gui::cb_window_thickness(Fl_Double_Window* o, void* v) {
 void gts_gui::cb_chkbtn_thickness_01_chk_i(Fl_Check_Button* o, void*) {
   if (o->value()) {
     cl_gts_gui.group_color_trace_01grp->activate();
-    cl_gts_gui.chkbtn_color_trace_01_chk->value(1);
+    cl_gts_gui.chkbtn_color_trace_01_chk->set();
     cl_gts_gui.group_thickness_01grp->activate();
 } else {
     cl_gts_gui.group_color_trace_01grp->deactivate();
-    cl_gts_gui.chkbtn_color_trace_01_chk->value(0);
+    cl_gts_gui.chkbtn_color_trace_01_chk->clear();
     cl_gts_gui.group_thickness_01grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();
@@ -2196,11 +2196,11 @@ void gts_gui::cb_valinp_thickness_01(Fl_Value_Input* o, void* v) {
 void gts_gui::cb_chkbtn_thickness_02_chk_i(Fl_Check_Button* o, void*) {
   if (o->value()) {
     cl_gts_gui.group_color_trace_02grp->activate();
-    cl_gts_gui.chkbtn_color_trace_02_chk->value(1);
+    cl_gts_gui.chkbtn_color_trace_02_chk->set();
     cl_gts_gui.group_thickness_02grp->activate();
 } else {
     cl_gts_gui.group_color_trace_02grp->deactivate();
-    cl_gts_gui.chkbtn_color_trace_02_chk->value(0);
+    cl_gts_gui.chkbtn_color_trace_02_chk->clear();
     cl_gts_gui.group_thickness_02grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();
@@ -2247,11 +2247,11 @@ void gts_gui::cb_valinp_thickness_02(Fl_Value_Input* o, void* v) {
 void gts_gui::cb_chkbtn_thickness_03_chk_i(Fl_Check_Button* o, void*) {
   if (o->value()) {
     cl_gts_gui.group_color_trace_03grp->activate();
-    cl_gts_gui.chkbtn_color_trace_03_chk->value(1);
+    cl_gts_gui.chkbtn_color_trace_03_chk->set();
     cl_gts_gui.group_thickness_03grp->activate();
 } else {
     cl_gts_gui.group_color_trace_03grp->deactivate();
-    cl_gts_gui.chkbtn_color_trace_03_chk->value(0);
+    cl_gts_gui.chkbtn_color_trace_03_chk->clear();
     cl_gts_gui.group_thickness_03grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();
@@ -2298,11 +2298,11 @@ void gts_gui::cb_valinp_thickness_03(Fl_Value_Input* o, void* v) {
 void gts_gui::cb_chkbtn_thickness_04_chk_i(Fl_Check_Button* o, void*) {
   if (o->value()) {
     cl_gts_gui.group_color_trace_04grp->activate();
-    cl_gts_gui.chkbtn_color_trace_04_chk->value(1);
+    cl_gts_gui.chkbtn_color_trace_04_chk->set();
     cl_gts_gui.group_thickness_04grp->activate();
 } else {
     cl_gts_gui.group_color_trace_04grp->deactivate();
-    cl_gts_gui.chkbtn_color_trace_04_chk->value(0);
+    cl_gts_gui.chkbtn_color_trace_04_chk->clear();
     cl_gts_gui.group_thickness_04grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();
@@ -2349,11 +2349,11 @@ void gts_gui::cb_valinp_thickness_04(Fl_Value_Input* o, void* v) {
 void gts_gui::cb_chkbtn_thickness_05_chk_i(Fl_Check_Button* o, void*) {
   if (o->value()) {
     cl_gts_gui.group_color_trace_05grp->activate();
-    cl_gts_gui.chkbtn_color_trace_05_chk->value(1);
+    cl_gts_gui.chkbtn_color_trace_05_chk->set();
     cl_gts_gui.group_thickness_05grp->activate();
 } else {
     cl_gts_gui.group_color_trace_05grp->deactivate();
-    cl_gts_gui.chkbtn_color_trace_05_chk->value(0);
+    cl_gts_gui.chkbtn_color_trace_05_chk->clear();
     cl_gts_gui.group_thickness_05grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();
@@ -2400,11 +2400,11 @@ void gts_gui::cb_valinp_thickness_05(Fl_Value_Input* o, void* v) {
 void gts_gui::cb_chkbtn_thickness_06_chk_i(Fl_Check_Button* o, void*) {
   if (o->value()) {
     cl_gts_gui.group_color_trace_06grp->activate();
-    cl_gts_gui.chkbtn_color_trace_06_chk->value(1);
+    cl_gts_gui.chkbtn_color_trace_06_chk->set();
     cl_gts_gui.group_thickness_06grp->activate();
 } else {
     cl_gts_gui.group_color_trace_06grp->deactivate();
-    cl_gts_gui.chkbtn_color_trace_06_chk->value(0);
+    cl_gts_gui.chkbtn_color_trace_06_chk->clear();
     cl_gts_gui.group_thickness_06grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();
@@ -5380,7 +5380,7 @@ Fl_Double_Window* gts_gui::make_window() {
       } // Fl_Button* o
       o->end();
     } // Fl_Group* o
-    { Fl_Group* o = new Fl_Group(0, 245, 200, 140, "Save RGB");
+    { Fl_Group* o = new Fl_Group(0, 245, 200, 185, "Save RGB");
       o->box(FL_BORDER_BOX);
       o->align(Fl_Align(FL_ALIGN_TOP_LEFT|FL_ALIGN_INSIDE));
       { chkbtn_level_rgb_trace_save_sw = new Fl_Check_Button(5, 265, 190, 20, "Save Trace Image");
@@ -5413,15 +5413,14 @@ Fl_Double_Window* gts_gui::make_window() {
         } // Fl_Group* o
         o->end();
       } // Fl_Group* o
-      o->end();
-    } // Fl_Group* o
-    { Fl_Group* o = new Fl_Group(0, 390, 200, 40, "Filter");
-      o->box(FL_BORDER_BOX);
-      o->align(Fl_Align(FL_ALIGN_TOP_LEFT|FL_ALIGN_INSIDE));
-      { chkbtn_color_trace_erase_1dot = new Fl_Check_Button(5, 405, 190, 25, "Erase dot noise");
-        chkbtn_color_trace_erase_1dot->down_box(FL_DOWN_BOX);
-        chkbtn_color_trace_erase_1dot->callback((Fl_Callback*)cb_chkbtn_color_trace_erase_1dot);
-      } // Fl_Check_Button* chkbtn_color_trace_erase_1dot
+      { Fl_Group* o = new Fl_Group(5, 385, 195, 40, "Filter");
+        o->align(Fl_Align(FL_ALIGN_TOP_LEFT|FL_ALIGN_INSIDE));
+        { chkbtn_color_trace_erase_1dot = new Fl_Check_Button(10, 400, 185, 25, "Erase dot noise");
+          chkbtn_color_trace_erase_1dot->down_box(FL_DOWN_BOX);
+          chkbtn_color_trace_erase_1dot->callback((Fl_Callback*)cb_chkbtn_color_trace_erase_1dot);
+        } // Fl_Check_Button* chkbtn_color_trace_erase_1dot
+        o->end();
+      } // Fl_Group* o
       o->end();
     } // Fl_Group* o
     window_level_set->set_non_modal();

--- a/sources/libcpp83gts_callback_and_action/gts_gui.cpp
+++ b/sources/libcpp83gts_callback_and_action/gts_gui.cpp
@@ -600,12 +600,12 @@ void gts_gui::cb_filinp_level_rgb_scan_dir(Fl_File_Input* o, void* v) {
   ((gts_gui*)(o->parent()->parent()->parent()->parent()->parent()->user_data()))->cb_filinp_level_rgb_scan_dir_i(o,v);
 }
 
-void gts_gui::cb_ligbut_level_rgb_scan_browse_sw_i(Fl_Button*, void*) {
+void gts_gui::cb_togbut_level_rgb_scan_browse_sw_i(Fl_Button*, void*) {
   cl_gts_master.cl_bro_level.cb_browse_sw();
 cl_gts_gui.window_level_browse->show();
 }
-void gts_gui::cb_ligbut_level_rgb_scan_browse_sw(Fl_Button* o, void* v) {
-  ((gts_gui*)(o->parent()->parent()->parent()->parent()->parent()->user_data()))->cb_ligbut_level_rgb_scan_browse_sw_i(o,v);
+void gts_gui::cb_togbut_level_rgb_scan_browse_sw(Fl_Button* o, void* v) {
+  ((gts_gui*)(o->parent()->parent()->parent()->parent()->parent()->user_data()))->cb_togbut_level_rgb_scan_browse_sw_i(o,v);
 }
 
 void gts_gui::cb_chkbtn_color_trace_erase_1dot_i(Fl_Check_Button*, void*) {
@@ -636,11 +636,11 @@ void gts_gui::cb_Rename(Fl_Menu_* o, void* v) {
   ((gts_gui*)(o->parent()->user_data()))->cb_Rename_i(o,v);
 }
 
-void gts_gui::cb_button_level_shift_number_i(Fl_Menu_*, void*) {
+void gts_gui::cb_menite_level_shift_number_i(Fl_Menu_*, void*) {
   cl_gts_master.cl_bro_level.cb_renumber();
 }
-void gts_gui::cb_button_level_shift_number(Fl_Menu_* o, void* v) {
-  ((gts_gui*)(o->parent()->user_data()))->cb_button_level_shift_number_i(o,v);
+void gts_gui::cb_menite_level_shift_number(Fl_Menu_* o, void* v) {
+  ((gts_gui*)(o->parent()->user_data()))->cb_menite_level_shift_number_i(o,v);
 }
 
 void gts_gui::cb_Explorer_i(Fl_Menu_*, void*) {
@@ -672,45 +672,45 @@ void gts_gui::cb_Explorer(Fl_Menu_* o, void* v) {
   ((gts_gui*)(o->parent()->user_data()))->cb_Explorer_i(o,v);
 }
 
-void gts_gui::cb_ligbut_level_view_sw_i(Fl_Menu_*, void*) {
+void gts_gui::cb_menite_level_view_sw_i(Fl_Menu_*, void*) {
   cl_gts_master.cl_bro_level.cb_info_redisplay();
 }
-void gts_gui::cb_ligbut_level_view_sw(Fl_Menu_* o, void* v) {
-  ((gts_gui*)(o->parent()->user_data()))->cb_ligbut_level_view_sw_i(o,v);
+void gts_gui::cb_menite_level_view_sw(Fl_Menu_* o, void* v) {
+  ((gts_gui*)(o->parent()->user_data()))->cb_menite_level_view_sw_i(o,v);
 }
 
-void gts_gui::cb_ligbut_level_info_rgb_sub_sw_i(Fl_Menu_*, void*) {
+void gts_gui::cb_menite_level_view_rgb_full_sw_i(Fl_Menu_*, void*) {
   cl_gts_master.cl_bro_level.cb_info_redisplay();
 }
-void gts_gui::cb_ligbut_level_info_rgb_sub_sw(Fl_Menu_* o, void* v) {
-  ((gts_gui*)(o->parent()->user_data()))->cb_ligbut_level_info_rgb_sub_sw_i(o,v);
+void gts_gui::cb_menite_level_view_rgb_full_sw(Fl_Menu_* o, void* v) {
+  ((gts_gui*)(o->parent()->user_data()))->cb_menite_level_view_rgb_full_sw_i(o,v);
 }
 
-void gts_gui::cb_ligbut_level_image_x1_sw_i(Fl_Menu_*, void*) {
+void gts_gui::cb_menite_level_image_x1_sw_i(Fl_Menu_*, void*) {
   cl_gts_master.cl_bro_level.cb_x1view_wintgl();
 }
-void gts_gui::cb_ligbut_level_image_x1_sw(Fl_Menu_* o, void* v) {
-  ((gts_gui*)(o->parent()->user_data()))->cb_ligbut_level_image_x1_sw_i(o,v);
+void gts_gui::cb_menite_level_image_x1_sw(Fl_Menu_* o, void* v) {
+  ((gts_gui*)(o->parent()->user_data()))->cb_menite_level_image_x1_sw_i(o,v);
 }
 
 Fl_Menu_Item gts_gui::menu_1[] = {
  {"File", 0,  0, 0, 64, FL_NORMAL_LABEL, 0, 14, 0},
  {"Make Directory...", 0,  (Fl_Callback*)gts_gui::cb_Make, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
  {"Rename...", 0,  (Fl_Callback*)gts_gui::cb_Rename, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
- {"Shift Number...", 0,  (Fl_Callback*)gts_gui::cb_button_level_shift_number, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
+ {"Shift Number...", 0,  (Fl_Callback*)gts_gui::cb_menite_level_shift_number, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
  {"Explorer...", 0,  (Fl_Callback*)gts_gui::cb_Explorer, 0, 0, FL_NORMAL_LABEL, 0, 14, 0},
  {0,0,0,0,0,0,0,0,0},
  {"View", 0,  0, 0, 64, FL_NORMAL_LABEL, 0, 14, 0},
- {"Image", 0,  (Fl_Callback*)gts_gui::cb_ligbut_level_view_sw, 0, 6, FL_NORMAL_LABEL, 0, 14, 0},
- {"_full", 0,  (Fl_Callback*)gts_gui::cb_ligbut_level_info_rgb_sub_sw, 0, 2, FL_NORMAL_LABEL, 0, 14, 0},
- {"X1", 0,  (Fl_Callback*)gts_gui::cb_ligbut_level_image_x1_sw, 0, 18, FL_NORMAL_LABEL, 0, 14, 0},
+ {"Image", 0,  (Fl_Callback*)gts_gui::cb_menite_level_view_sw, 0, 6, FL_NORMAL_LABEL, 0, 14, 0},
+ {"_full", 0,  (Fl_Callback*)gts_gui::cb_menite_level_view_rgb_full_sw, 0, 2, FL_NORMAL_LABEL, 0, 14, 0},
+ {"X1", 0,  (Fl_Callback*)gts_gui::cb_menite_level_image_x1_sw, 0, 18, FL_NORMAL_LABEL, 0, 14, 0},
  {0,0,0,0,0,0,0,0,0},
  {0,0,0,0,0,0,0,0,0}
 };
-Fl_Menu_Item* gts_gui::button_level_shift_number = gts_gui::menu_1 + 3;
-Fl_Menu_Item* gts_gui::ligbut_level_view_sw = gts_gui::menu_1 + 7;
-Fl_Menu_Item* gts_gui::ligbut_level_info_rgb_sub_sw = gts_gui::menu_1 + 8;
-Fl_Menu_Item* gts_gui::ligbut_level_image_x1_sw = gts_gui::menu_1 + 9;
+Fl_Menu_Item* gts_gui::menite_level_shift_number = gts_gui::menu_1 + 3;
+Fl_Menu_Item* gts_gui::menite_level_view_sw = gts_gui::menu_1 + 7;
+Fl_Menu_Item* gts_gui::menite_level_view_rgb_full_sw = gts_gui::menu_1 + 8;
+Fl_Menu_Item* gts_gui::menite_level_image_x1_sw = gts_gui::menu_1 + 9;
 
 void gts_gui::cb__i(Fl_Button*, void*) {
   cl_gts_master.cl_bro_level.cb_dir_up();
@@ -5398,11 +5398,12 @@ Fl_Double_Window* gts_gui::make_window() {
               filinp_level_rgb_scan_dir->callback((Fl_Callback*)cb_filinp_level_rgb_scan_dir);
               filinp_level_rgb_scan_dir->align(Fl_Align(FL_ALIGN_TOP_LEFT));
               filinp_level_rgb_scan_dir->when(FL_WHEN_CHANGED);
+              filinp_level_rgb_scan_dir->deactivate();
             } // Fl_File_Input* filinp_level_rgb_scan_dir
-            { ligbut_level_rgb_scan_browse_sw = new Fl_Button(170, 330, 15, 25, "<");
-              ligbut_level_rgb_scan_browse_sw->type(1);
-              ligbut_level_rgb_scan_browse_sw->callback((Fl_Callback*)cb_ligbut_level_rgb_scan_browse_sw);
-            } // Fl_Button* ligbut_level_rgb_scan_browse_sw
+            { togbut_level_rgb_scan_browse_sw = new Fl_Button(170, 330, 15, 25, "<");
+              togbut_level_rgb_scan_browse_sw->type(1);
+              togbut_level_rgb_scan_browse_sw->callback((Fl_Callback*)cb_togbut_level_rgb_scan_browse_sw);
+            } // Fl_Button* togbut_level_rgb_scan_browse_sw
             o->end();
           } // Fl_Group* o
           { chkbtn_level_rgb_with_full_sw = new Fl_Check_Button(15, 360, 175, 20, "Add _full in level");
@@ -5435,13 +5436,14 @@ Fl_Double_Window* gts_gui::make_window() {
       { Fl_Button* o = new Fl_Button(5, 30, 15, 25, "<");
         o->shortcut(0x40075);
         o->callback((Fl_Callback*)cb_);
+        o->hide();
       } // Fl_Button* o
-      { choice_level_list_form = new Fl_Choice(25, 30, 80, 25);
+      { choice_level_list_form = new Fl_Choice(5, 30, 80, 25);
         choice_level_list_form->down_box(FL_BORDER_BOX);
         choice_level_list_form->callback((Fl_Callback*)cb_choice_level_list_form);
         choice_level_list_form->menu(menu_choice_level_list_form);
       } // Fl_Choice* choice_level_list_form
-      { Fl_Box* o = new Fl_Box(105, 30, 275, 25);
+      { Fl_Box* o = new Fl_Box(85, 30, 295, 25);
         Fl_Group::current()->resizable(o);
       } // Fl_Box* o
       o->end();

--- a/sources/libcpp83gts_callback_and_action/gts_gui.fl
+++ b/sources/libcpp83gts_callback_and_action/gts_gui.fl
@@ -609,7 +609,7 @@ cl_gts_gui.window_level_browse->show();}
       }
     }
     Fl_Window window_level_browse {
-      label Browse
+      label {Level Browse}
       callback {cl_gts_master.cl_bro_level.cb_cancel();}
       xywh {50 50 380 425} type Double resizable modal size_range {180 120 1920 1200} visible
     } {

--- a/sources/libcpp83gts_callback_and_action/gts_gui.fl
+++ b/sources/libcpp83gts_callback_and_action/gts_gui.fl
@@ -581,9 +581,9 @@ cl_gts_gui.menite_level->clear();}
               Fl_File_Input filinp_level_rgb_scan_dir {
                 label Directory
                 callback {cl_gts_master.cl_bro_level.cb_rgb_scan_dir();}
-                xywh {15 320 155 35} align 5 when 1
+                xywh {15 320 155 35} align 5 when 1 deactivate
               }
-              Fl_Button ligbut_level_rgb_scan_browse_sw {
+              Fl_Button togbut_level_rgb_scan_browse_sw {
                 label {<}
                 callback {cl_gts_master.cl_bro_level.cb_browse_sw();
 cl_gts_gui.window_level_browse->show();}
@@ -630,7 +630,7 @@ cl_gts_gui.window_level_browse->show();}
             callback {cl_gts_master.cl_bro_level.cb_rename();}
             xywh {0 0 30 20}
           }
-          MenuItem button_level_shift_number {
+          MenuItem menite_level_shift_number {
             label {Shift Number...}
             callback {cl_gts_master.cl_bro_level.cb_renumber();}
             xywh {0 0 30 20}
@@ -668,17 +668,17 @@ cl_gts_gui.window_level_browse->show();}
           label View open
           xywh {0 0 62 20}
         } {
-          MenuItem ligbut_level_view_sw {
+          MenuItem menite_level_view_sw {
             label Image
             callback {cl_gts_master.cl_bro_level.cb_info_redisplay();}
             xywh {0 0 30 20} type Toggle value 1
           }
-          MenuItem ligbut_level_info_rgb_sub_sw {
+          MenuItem menite_level_view_rgb_full_sw {
             label _full
             callback {cl_gts_master.cl_bro_level.cb_info_redisplay();}
             xywh {0 0 30 20} type Toggle
           }
-          MenuItem ligbut_level_image_x1_sw {
+          MenuItem menite_level_image_x1_sw {
             label X1
             callback {cl_gts_master.cl_bro_level.cb_x1view_wintgl();}
             xywh {0 0 30 20} type Toggle hide
@@ -691,11 +691,11 @@ cl_gts_gui.window_level_browse->show();}
         Fl_Button {} {
           label {<}
           callback {cl_gts_master.cl_bro_level.cb_dir_up();}
-          xywh {5 30 15 25} shortcut 0x40075
+          xywh {5 30 15 25} shortcut 0x40075 hide
         }
         Fl_Choice choice_level_list_form {
           callback {cl_gts_master.cl_bro_level.cb_file_or_level();} open
-          xywh {25 30 80 25} down_box BORDER_BOX
+          xywh {5 30 80 25} down_box BORDER_BOX
         } {
           MenuItem {} {
             label File
@@ -707,7 +707,7 @@ cl_gts_gui.window_level_browse->show();}
           }
         }
         Fl_Box {} {
-          xywh {105 30 275 25} resizable
+          xywh {85 30 295 25} resizable
         }
       }
       Fl_Tile {} {open

--- a/sources/libcpp83gts_callback_and_action/gts_gui.fl
+++ b/sources/libcpp83gts_callback_and_action/gts_gui.fl
@@ -559,7 +559,7 @@ cl_gts_gui.menite_level->clear();}
       }
       Fl_Group {} {
         label {Save RGB} open
-        xywh {0 245 200 140} box BORDER_BOX align 21
+        xywh {0 245 200 185} box BORDER_BOX align 21
       } {
         Fl_Check_Button chkbtn_level_rgb_trace_save_sw {
           label {Save Trace Image}
@@ -596,15 +596,15 @@ cl_gts_gui.window_level_browse->show();}
             }
           }
         }
-      }
-      Fl_Group {} {
-        label Filter open
-        xywh {0 390 200 40} box BORDER_BOX align 21
-      } {
-        Fl_Check_Button chkbtn_color_trace_erase_1dot {
-          label {Erase dot noise}
-          callback {cl_gts_master.cb_real_time_on_off();}
-          xywh {5 405 190 25} down_box DOWN_BOX
+        Fl_Group {} {
+          label Filter open
+          xywh {5 385 195 40} align 21
+        } {
+          Fl_Check_Button chkbtn_color_trace_erase_1dot {
+            label {Erase dot noise}
+            callback {cl_gts_master.cb_real_time_on_off();}
+            xywh {10 400 185 25} down_box DOWN_BOX
+          }
         }
       }
     }
@@ -1262,11 +1262,11 @@ cl_gts_gui.menite_edit_hsv_min_max->clear();}
         Fl_Check_Button chkbtn_color_trace_01_chk {
           callback {if (o->value()) {
     cl_gts_gui.group_color_trace_01grp->activate();
-    cl_gts_gui.chkbtn_thickness_01_chk->value(1);
+    cl_gts_gui.chkbtn_thickness_01_chk->set();
     cl_gts_gui.group_thickness_01grp->activate();
 } else {
     cl_gts_gui.group_color_trace_01grp->deactivate();
-    cl_gts_gui.chkbtn_thickness_01_chk->value(0);
+    cl_gts_gui.chkbtn_thickness_01_chk->clear();
     cl_gts_gui.group_thickness_01grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();}
@@ -1366,11 +1366,11 @@ cl_gts_master.cb_color_trace_src_redraw_image();}
         Fl_Check_Button chkbtn_color_trace_02_chk {
           callback {if (o->value()) {
     cl_gts_gui.group_color_trace_02grp->activate();
-    cl_gts_gui.chkbtn_thickness_02_chk->value(1);
+    cl_gts_gui.chkbtn_thickness_02_chk->set();
     cl_gts_gui.group_thickness_02grp->activate();
 } else {
     cl_gts_gui.group_color_trace_02grp->deactivate();
-    cl_gts_gui.chkbtn_thickness_02_chk->value(0);
+    cl_gts_gui.chkbtn_thickness_02_chk->clear();
     cl_gts_gui.group_thickness_02grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();}
@@ -1470,11 +1470,11 @@ cl_gts_master.cb_color_trace_src_redraw_image();}
         Fl_Check_Button chkbtn_color_trace_03_chk {
           callback {if (o->value()) {
     cl_gts_gui.group_color_trace_03grp->activate();
-    cl_gts_gui.chkbtn_thickness_03_chk->value(1);
+    cl_gts_gui.chkbtn_thickness_03_chk->set();
     cl_gts_gui.group_thickness_03grp->activate();
 } else {
     cl_gts_gui.group_color_trace_03grp->deactivate();
-    cl_gts_gui.chkbtn_thickness_03_chk->value(0);
+    cl_gts_gui.chkbtn_thickness_03_chk->clear();
     cl_gts_gui.group_thickness_03grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();}
@@ -1574,11 +1574,11 @@ cl_gts_master.cb_color_trace_src_redraw_image();}
         Fl_Check_Button chkbtn_color_trace_04_chk {
           callback {if (o->value()) {
     cl_gts_gui.group_color_trace_04grp->activate();
-    cl_gts_gui.chkbtn_thickness_04_chk->value(1);
+    cl_gts_gui.chkbtn_thickness_04_chk->set();
     cl_gts_gui.group_thickness_04grp->activate();
 } else {
     cl_gts_gui.group_color_trace_04grp->deactivate();
-    cl_gts_gui.chkbtn_thickness_04_chk->value(0);
+    cl_gts_gui.chkbtn_thickness_04_chk->clear();
     cl_gts_gui.group_thickness_04grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();}
@@ -1678,11 +1678,11 @@ cl_gts_master.cb_color_trace_src_redraw_image();}
         Fl_Check_Button chkbtn_color_trace_05_chk {
           callback {if (o->value()) {
     cl_gts_gui.group_color_trace_05grp->activate();
-    cl_gts_gui.chkbtn_thickness_05_chk->value(1);
+    cl_gts_gui.chkbtn_thickness_05_chk->set();
     cl_gts_gui.group_thickness_05grp->activate();
 } else {
     cl_gts_gui.group_color_trace_05grp->deactivate();
-    cl_gts_gui.chkbtn_thickness_05_chk->value(0);
+    cl_gts_gui.chkbtn_thickness_05_chk->clear();
     cl_gts_gui.group_thickness_05grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();}
@@ -1782,11 +1782,11 @@ cl_gts_master.cb_color_trace_src_redraw_image();}
         Fl_Check_Button chkbtn_color_trace_06_chk {
           callback {if (o->value()) {
     cl_gts_gui.group_color_trace_06grp->activate();
-    cl_gts_gui.chkbtn_thickness_06_chk->value(1);
+    cl_gts_gui.chkbtn_thickness_06_chk->set();
     cl_gts_gui.group_thickness_06grp->activate();
 } else {
     cl_gts_gui.group_color_trace_06grp->deactivate();
-    cl_gts_gui.chkbtn_thickness_06_chk->value(0);
+    cl_gts_gui.chkbtn_thickness_06_chk->clear();
     cl_gts_gui.group_thickness_06grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();}
@@ -2051,11 +2051,11 @@ cl_gts_gui.menite_edit_hsv_min_max->clear();}
           label 1
           callback {if (o->value()) {
     cl_gts_gui.group_color_trace_01grp->activate();
-    cl_gts_gui.chkbtn_color_trace_01_chk->value(1);
+    cl_gts_gui.chkbtn_color_trace_01_chk->set();
     cl_gts_gui.group_thickness_01grp->activate();
 } else {
     cl_gts_gui.group_color_trace_01grp->deactivate();
-    cl_gts_gui.chkbtn_color_trace_01_chk->value(0);
+    cl_gts_gui.chkbtn_color_trace_01_chk->clear();
     cl_gts_gui.group_thickness_01grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();}
@@ -2096,11 +2096,11 @@ cl_gts_master.cb_color_trace_src_redraw_image();}
           label 2
           callback {if (o->value()) {
     cl_gts_gui.group_color_trace_02grp->activate();
-    cl_gts_gui.chkbtn_color_trace_02_chk->value(1);
+    cl_gts_gui.chkbtn_color_trace_02_chk->set();
     cl_gts_gui.group_thickness_02grp->activate();
 } else {
     cl_gts_gui.group_color_trace_02grp->deactivate();
-    cl_gts_gui.chkbtn_color_trace_02_chk->value(0);
+    cl_gts_gui.chkbtn_color_trace_02_chk->clear();
     cl_gts_gui.group_thickness_02grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();}
@@ -2141,11 +2141,11 @@ cl_gts_master.cb_color_trace_src_redraw_image();}
           label 3
           callback {if (o->value()) {
     cl_gts_gui.group_color_trace_03grp->activate();
-    cl_gts_gui.chkbtn_color_trace_03_chk->value(1);
+    cl_gts_gui.chkbtn_color_trace_03_chk->set();
     cl_gts_gui.group_thickness_03grp->activate();
 } else {
     cl_gts_gui.group_color_trace_03grp->deactivate();
-    cl_gts_gui.chkbtn_color_trace_03_chk->value(0);
+    cl_gts_gui.chkbtn_color_trace_03_chk->clear();
     cl_gts_gui.group_thickness_03grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();}
@@ -2186,11 +2186,11 @@ cl_gts_master.cb_color_trace_src_redraw_image();}
           label 4
           callback {if (o->value()) {
     cl_gts_gui.group_color_trace_04grp->activate();
-    cl_gts_gui.chkbtn_color_trace_04_chk->value(1);
+    cl_gts_gui.chkbtn_color_trace_04_chk->set();
     cl_gts_gui.group_thickness_04grp->activate();
 } else {
     cl_gts_gui.group_color_trace_04grp->deactivate();
-    cl_gts_gui.chkbtn_color_trace_04_chk->value(0);
+    cl_gts_gui.chkbtn_color_trace_04_chk->clear();
     cl_gts_gui.group_thickness_04grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();}
@@ -2231,11 +2231,11 @@ cl_gts_master.cb_color_trace_src_redraw_image();}
           label 5
           callback {if (o->value()) {
     cl_gts_gui.group_color_trace_05grp->activate();
-    cl_gts_gui.chkbtn_color_trace_05_chk->value(1);
+    cl_gts_gui.chkbtn_color_trace_05_chk->set();
     cl_gts_gui.group_thickness_05grp->activate();
 } else {
     cl_gts_gui.group_color_trace_05grp->deactivate();
-    cl_gts_gui.chkbtn_color_trace_05_chk->value(0);
+    cl_gts_gui.chkbtn_color_trace_05_chk->clear();
     cl_gts_gui.group_thickness_05grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();}
@@ -2276,11 +2276,11 @@ cl_gts_master.cb_color_trace_src_redraw_image();}
           label 6
           callback {if (o->value()) {
     cl_gts_gui.group_color_trace_06grp->activate();
-    cl_gts_gui.chkbtn_color_trace_06_chk->value(1);
+    cl_gts_gui.chkbtn_color_trace_06_chk->set();
     cl_gts_gui.group_thickness_06grp->activate();
 } else {
     cl_gts_gui.group_color_trace_06grp->deactivate();
-    cl_gts_gui.chkbtn_color_trace_06_chk->value(0);
+    cl_gts_gui.chkbtn_color_trace_06_chk->clear();
     cl_gts_gui.group_thickness_06grp->deactivate();
 }
 cl_gts_master.cb_color_trace_src_redraw_image();}

--- a/sources/libcpp83gts_callback_and_action/gts_gui.fl
+++ b/sources/libcpp83gts_callback_and_action/gts_gui.fl
@@ -20,7 +20,7 @@ class gts_gui {open
     Fl_Window window_opengl {
       label GTS
       callback {cl_gts_master.cb_quit();}
-      xywh {50 50 720 565} type Double resizable visible
+      xywh {-32000 -32000 720 565} type Double hide resizable
     } {
       Fl_Menu_Bar {} {open
         xywh {0 0 720 25}
@@ -406,7 +406,7 @@ fl_message( ost.str().c_str() );}
     }
     Fl_Window window_next_scan {
       label {Next Scan}
-      xywh {50 50 545 100} type Double modal visible
+      xywh {-32000 -32000 545 100} type Double hide modal
     } {
       Fl_Button button_rescan {
         label Rescan
@@ -433,57 +433,180 @@ fl_message( ost.str().c_str() );}
         xywh {180 40 145 60} align 6 textsize 60
       }
     }
-    Fl_Window window_level {
-      label {Browse Level}
-      callback {cl_gts_master.cl_bro_level.cb_cancel();}
-      xywh {50 50 380 630} type Double resizable non_modal size_range {370 300 0 0} visible
+    Fl_Window window_level_set {
+      label Level open
+      xywh {-920 -220 200 425} type Double resizable non_modal size_range {200 360 1000 360} visible
     } {
-      Fl_Button {} {
-        callback {cl_gts_master.cl_bro_level.cb_dir_up();}
-        xywh {0 0 0 0} shortcut 0x40075
-      }
-      Fl_File_Input filinp_level_dir {
-        label Directory
-        callback {cl_gts_master.cl_bro_level.cb_dir();}
-        xywh {0 20 380 35} box BORDER_BOX align 5 when 1
-      }
       Fl_Group {} {open
-        xywh {0 60 380 25}
+        xywh {0 0 200 235} box BORDER_BOX
       } {
-        Fl_Choice choice_level_list_form {
-          callback {cl_gts_master.cl_bro_level.cb_file_or_level();} open
-          xywh {5 60 80 25} down_box BORDER_BOX
+        Fl_Button ligbut_level_rgb_scan_browse_sw {
+          label {Browse...}
+          callback {cl_gts_master.cl_bro_level.cb_browse_sw();}
+          xywh {5 5 190 25}
+        }
+        Fl_Group {} {open
+          xywh {0 30 200 170}
+        } {
+          Fl_Group {} {open
+            xywh {0 30 200 50}
+          } {
+            Fl_File_Input filinp_level_dir {
+              label Directory
+              callback {cl_gts_master.cl_bro_level.cb_dir();}
+              xywh {0 45 200 35} box BORDER_BOX align 5 when 1 resizable
+            }
+          }
+          Fl_Group {} {open
+            xywh {0 80 200 30}
+          } {
+            Fl_Box {} {
+              xywh {0 85 50 25}
+            }
+            Fl_Input strinp_level_file {
+              label Level
+              callback {cl_gts_master.cl_bro_level.cb_level_name();}
+              xywh {50 85 150 25} box BORDER_BOX when 1 resizable
+            }
+          }
+          Fl_Group {} {open
+            xywh {0 110 200 30}
+          } {
+            Fl_Box {} {
+              xywh {0 115 50 25}
+            }
+            Fl_Value_Input valinp_level_start {
+              label Start
+              xywh {50 115 40 25} box BORDER_BOX minimum 1 maximum 9999 value 1
+            }
+            Fl_Box {} {
+              xywh {90 115 110 25} resizable
+            }
+          }
+          Fl_Group {} {open
+            xywh {0 140 200 30}
+          } {
+            Fl_Box {} {
+              xywh {0 145 50 25}
+            }
+            Fl_Value_Input valinp_level_end {
+              label End
+              xywh {50 145 40 25} box BORDER_BOX minimum 1 maximum 9999 value 1
+            }
+            Fl_Box {} {
+              xywh {90 145 110 25} resizable
+            }
+          }
+          Fl_Group {} {open
+            xywh {0 170 200 30}
+          } {
+            Fl_Box {} {
+              xywh {0 175 50 25}
+            }
+            Fl_Choice choice_level_image_file_format {
+              label Format
+              callback {cl_gts_master.cl_bro_level.cb_set_image_file_extension();} open
+              xywh {50 175 100 25} down_box BORDER_BOX
+            } {
+              MenuItem {} {
+                label {TIFF(*.tif)}
+                xywh {5 5 30 20}
+              }
+              MenuItem {} {
+                label {TGA(*.tga)}
+                xywh {5 5 30 20}
+              }
+            }
+            Fl_Box {} {
+              xywh {150 175 50 25} resizable
+            }
+          }
+        }
+        Fl_Button {} {
+          label {Set Number}
+          callback {cl_gts_master.cl_bro_level.cb_ok();}
+          xywh {5 205 190 25}
+        }
+      }
+      Fl_Group {} {
+        label {Save RGB} open
+        xywh {0 240 200 140} box BORDER_BOX align 21
+      } {
+        Fl_Check_Button chkbtn_level_rgb_trace_save_sw {
+          label {Save Trace Image}
+          xywh {5 260 190 20} down_box DOWN_BOX resizable
+        }
+        Fl_Group {} {open
+          xywh {5 280 190 100}
+        } {
+          Fl_Check_Button chkbtn_level_rgb_full_save_sw {
+            label {Save Scan Image}
+            xywh {5 280 190 20} down_box DOWN_BOX value 1 resizable
+          }
+          Fl_Group {} {open
+            xywh {10 300 180 75} box BORDER_BOX
+          } {
+            Fl_Group {} {open
+              xywh {15 300 170 55}
+            } {
+              Fl_File_Input filinp_level_rgb_scan_dir {
+                label Directory
+                callback {cl_gts_master.cl_bro_level.cb_rgb_scan_dir();}
+                xywh {15 315 155 35} align 5 when 1 resizable
+              }
+              Fl_Button {} {
+                label {<}
+                xywh {170 325 15 25}
+              }
+            }
+            Fl_Check_Button chkbtn_level_rgb_with_full_sw {
+              label {Add _full in level}
+              xywh {15 355 175 20} down_box DOWN_BOX value 1 resizable
+            }
+          }
+        }
+      }
+      Fl_Group {} {
+        label Filter open
+        xywh {0 385 200 40} box BORDER_BOX align 21
+      } {
+        Fl_Check_Button chkbtn_color_trace_erase_1dot {
+          label {Erase dot noise}
+          callback {cl_gts_master.cb_real_time_on_off();}
+          xywh {5 400 190 25} down_box DOWN_BOX resizable
+        }
+      }
+    }
+    Fl_Window window_level_browse {
+      label Browse
+      callback {cl_gts_master.cl_bro_level.cb_cancel();} open
+      xywh {-1330 -225 380 425} type Double resizable modal size_range {370 470 0 0} visible
+    } {
+      Fl_Menu_Bar {} {open
+        xywh {0 0 380 25}
+      } {
+        Submenu {} {
+          label File open
+          xywh {0 0 62 20}
         } {
           MenuItem {} {
-            label File
-            xywh {15 15 100 20}
+            label {Make Directory...}
+            callback {cl_gts_master.cl_bro_level.cb_mkdir();}
+            xywh {0 0 30 20}
           }
           MenuItem {} {
-            label Level
-            xywh {20 20 100 20}
+            label {Rename...}
+            callback {cl_gts_master.cl_bro_level.cb_rename();}
+            xywh {0 0 30 20}
           }
-        }
-        Fl_Button {} {
-          label Makedir
-          callback {cl_gts_master.cl_bro_level.cb_mkdir();}
-          xywh {90 60 60 25}
-        }
-        Fl_Button {} {
-          label Rename
-          callback {cl_gts_master.cl_bro_level.cb_rename();}
-          xywh {155 60 60 25}
-        }
-        Fl_Button button_level_shift_number {
-          label {Shift number}
-          callback {cl_gts_master.cl_bro_level.cb_renumber();}
-          xywh {220 60 85 25} hide
-        }
-        Fl_Box {} {
-          xywh {305 60 10 25} resizable
-        }
-        Fl_Button {} {
-          label Explorer
-          callback {std::string comm("C:\\\\WINDOWS\\\\explorer.exe");
+          MenuItem button_level_shift_number {
+            label {Shift Number...}
+            callback {cl_gts_master.cl_bro_level.cb_renumber();} selected
+            xywh {0 0 30 20}
+          }
+          MenuItem {} {
+            label {Explorer...}
+            callback {std::string comm("C:\\\\WINDOWS\\\\explorer.exe");
 \# ifdef _WIN32
     comm += ' ';
     comm += cl_gts_gui.filinp_level_dir->value();
@@ -506,202 +629,122 @@ fl_message( ost.str().c_str() );}
     ::CloseHandle(pi.hProcess);
     ::CloseHandle(pi.hThread);
 \# endif}
-          xywh {315 60 60 25}
-          code0 {\#include <iostream>}
+            xywh {0 0 30 20}
+            code0 {\#include <iostream>}
+          }
+        }
+        Submenu {} {
+          label View open
+          xywh {0 0 62 20}
+        } {
+          MenuItem ligbut_level_view_sw {
+            label Image
+            callback {cl_gts_master.cl_bro_level.cb_info_redisplay();}
+            xywh {0 0 30 20} type Toggle
+          }
+          MenuItem ligbut_level_info_rgb_sub_sw {
+            label _full
+            callback {cl_gts_master.cl_bro_level.cb_info_redisplay();}
+            xywh {0 0 30 20} type Toggle
+          }
+          MenuItem ligbut_level_image_x1_sw {
+            label X1
+            callback {cl_gts_master.cl_bro_level.cb_x1view_wintgl();}
+            xywh {0 0 30 20} type Toggle
+          }
         }
       }
-      Fl_Tile {} {
-        xywh {0 90 380 330} align 0 resizable
+      Fl_Group {} {open
+        xywh {0 30 380 25}
+      } {
+        Fl_Button {} {
+          label {<}
+          callback {cl_gts_master.cl_bro_level.cb_dir_up();}
+          xywh {5 30 15 25} shortcut 0x40075
+        }
+        Fl_Choice choice_level_list_form {
+          callback {cl_gts_master.cl_bro_level.cb_file_or_level();} open
+          xywh {25 30 80 25} down_box BORDER_BOX
+        } {
+          MenuItem {} {
+            label Level
+            xywh {25 25 100 20}
+          }
+          MenuItem {} {
+            label File
+            xywh {20 20 100 20}
+          }
+        }
+        Fl_Box {} {
+          xywh {105 30 275 25} resizable
+        }
+      }
+      Fl_Tile {} {open
+        xywh {0 60 380 330} align 0 resizable
       } {
         Fl_Group {} {open
-          xywh {0 90 150 330} box DOWN_BOX
+          xywh {0 60 150 330} box DOWN_BOX
         } {
           Fl_Browser selbro_level_list {
             callback {cl_gts_master.cl_bro_level.cb_list();}
-            xywh {0 90 150 330} type Hold align 0
+            xywh {0 60 150 330} type Hold align 0
           }
         }
         Fl_Group {} {open
-          xywh {150 90 230 150} box DOWN_BOX
+          xywh {150 60 230 150} box DOWN_BOX
         } {
           Fl_Box box_level_image {
-            xywh {150 90 230 150}
+            xywh {150 60 230 150}
           }
         }
         Fl_Group {} {open
-          xywh {150 240 230 180} box DOWN_BOX
+          xywh {150 210 230 180} box DOWN_BOX
         } {
           Fl_Text_Display txtdis_level_info {
-            xywh {150 240 230 155} color 50 align 4 resizable
+            xywh {150 210 230 155} color 50 align 4 resizable
           }
           Fl_Group {} {open
-            xywh {150 395 230 25}
+            xywh {150 365 230 25}
           } {
             Fl_Scrollbar scroll_level_info_number {
               callback {cl_gts_gui.valinp_level_crnt->value(
 cl_gts_gui.scroll_level_info_number->value()
 );
 cl_gts_master.cl_bro_level.cb_info_redisplay();}
-              xywh {150 395 190 25} type Horizontal box BORDER_BOX when 4 resizable
+              xywh {150 365 190 25} type Horizontal box BORDER_BOX when 4 resizable
             }
             Fl_Value_Input valinp_level_crnt {
               callback {((Fl_Valuator *)(cl_gts_gui.scroll_level_info_number))->value(
 (double)cl_gts_gui.valinp_level_crnt->value()
 );
 cl_gts_master.cl_bro_level.cb_info_redisplay();}
-              xywh {340 395 40 25} when 8 minimum 1 maximum 9999 value 1
+              xywh {340 365 40 25} when 8 minimum 1 maximum 9999 value 1
             }
           }
         }
       }
       Fl_Group {} {open
-        xywh {0 425 380 25}
-      } {
-        Fl_Box {} {
-          xywh {0 425 80 25}
-        }
-        Fl_Input strinp_level_file {
-          label Level
-          callback {cl_gts_master.cl_bro_level.cb_level_name();}
-          xywh {80 425 300 25} box BORDER_BOX when 1 resizable
-        }
-      }
-      Fl_Group {} {open
-        xywh {0 455 380 25}
-      } {
-        Fl_Value_Input valinp_level_start {
-          label Start
-          xywh {80 455 50 25} box BORDER_BOX minimum 1 maximum 9999 value 1
-        }
-        Fl_Box {} {
-          xywh {130 455 110 25} resizable
-        }
-        Fl_Light_Button ligbut_level_image_x1_sw {
-          label x1
-          callback {cl_gts_master.cl_bro_level.cb_x1view_wintgl();}
-          xywh {240 455 35 25}
-        }
-        Fl_Light_Button ligbut_level_view_sw {
-          label {View image}
-          callback {cl_gts_master.cl_bro_level.cb_info_redisplay();}
-          xywh {280 455 95 25}
-        }
-      }
-      Fl_Group {} {open
-        xywh {0 485 380 25}
-      } {
-        Fl_Choice choice_level_continue_type {
-          callback {if (o->value() == 0) {
- cl_gts_gui.valinp_level_end->show();
- cl_gts_gui.choice_level_endless_direction->hide();
-} else {
- cl_gts_gui.valinp_level_end->hide();
- cl_gts_gui.choice_level_endless_direction->show();
-}} open
-          xywh {0 485 80 25} down_box BORDER_BOX
-        } {
-          MenuItem {} {
-            label End
-            xywh {0 0 30 20}
-          }
-          MenuItem {} {
-            label Endless
-            xywh {0 0 30 20}
-          }
-        }
-        Fl_Choice choice_level_endless_direction {open
-          xywh {80 485 50 25} down_box BORDER_BOX
-        } {
-          MenuItem {} {
-            label {+1}
-            xywh {0 0 30 20}
-          }
-          MenuItem {} {
-            label {-1}
-            xywh {0 0 30 20}
-          }
-        }
-        Fl_Value_Input valinp_level_end {
-          xywh {80 485 50 25} box BORDER_BOX minimum 1 maximum 9999 value 1
-        }
-        Fl_Box {} {
-          xywh {130 485 250 25} resizable
-        }
-      }
-      Fl_Group {} {open
-        xywh {0 515 380 25}
-      } {
-        Fl_Choice choice_level_image_file_format {
-          label Format
-          callback {cl_gts_master.cl_bro_level.cb_set_image_file_extension();} open
-          xywh {80 515 65 25} down_box BORDER_BOX
-        } {
-          MenuItem {} {
-            label TIFF
-            xywh {0 0 30 20}
-          }
-          MenuItem {} {
-            label TGA
-            xywh {0 0 30 20}
-          }
-        }
-        Fl_Box {} {
-          xywh {145 515 235 25} resizable
-        }
-      }
-      Fl_Group {} {open
-        xywh {0 545 380 50}
-      } {
-        Fl_File_Input filinp_level_rgb_scan_dir {
-          label {RGB scan dir}
-          callback {cl_gts_master.cl_bro_level.cb_rgb_scan_dir();}
-          xywh {0 560 135 35} align 5 when 1 deactivate resizable
-        }
-        Fl_Check_Button chkbtn_level_rgb_trace_save_sw {
-          label {S.C.T.}
-          tooltip {Save Color Trace level} xywh {135 575 60 20} down_box DOWN_BOX
-        }
-        Fl_Check_Button chkbtn_level_rgb_full_save_sw {
-          label {S.Full}
-          tooltip {Save RGB Full  level} xywh {195 575 60 20} down_box DOWN_BOX value 1
-        }
-        Fl_Check_Button chkbtn_level_rgb_with_full_sw {
-          label With_full
-          tooltip {With _full in RGB full name} xywh {195 553 75 20} down_box DOWN_BOX value 1
-        }
-        Fl_Light_Button ligbut_level_rgb_scan_browse_sw {
-          label Browse
-          callback {cl_gts_master.cl_bro_level.cb_browse_sw();}
-          xywh {255 570 70 25}
-        }
-        Fl_Light_Button ligbut_level_info_rgb_sub_sw {
-          label Full
-          callback {cl_gts_master.cl_bro_level.cb_info_redisplay();}
-          xywh {325 570 50 25} hide
-        }
-      }
-      Fl_Group {} {open
-        xywh {0 600 380 24}
+        xywh {0 395 380 24}
       } {
         Fl_Button {} {
           label OK
           callback {cl_gts_master.cl_bro_level.cb_ok();}
-          xywh {10 600 80 24}
+          xywh {10 395 80 24}
         }
         Fl_Box {} {
-          xywh {90 600 200 24} resizable
+          xywh {90 395 200 24} resizable
         }
         Fl_Button {} {
           label Cancel
           callback {cl_gts_master.cl_bro_level.cb_cancel();}
-          xywh {290 600 80 24}
+          xywh {290 395 80 24}
         }
       }
     }
     Fl_Window window_x1view {
       label x1
       callback {cl_gts_master.cl_bro_level.cb_x1view_cancel();}
-      xywh {50 50 300 300} type Double align 0 resizable non_modal visible
+      xywh {-32000 -32000 300 300} type Double align 0 hide resizable non_modal
     } {
       Fl_Scroll scroll_level_x1view {open
         xywh {0 0 300 300} align 0 resizable
@@ -714,7 +757,7 @@ cl_gts_master.cl_bro_level.cb_info_redisplay();}
     Fl_Window window_config_load {
       label {Load Config}
       callback {cl_gts_master.cl_bro_config.cb_load_cancel();}
-      xywh {50 50 300 390} type Double resizable non_modal size_range {200 125 0 0} visible
+      xywh {-32000 -32000 300 390} type Double hide resizable non_modal size_range {200 125 0 0}
     } {
       Fl_Button {} {
         callback {cl_gts_master.cl_bro_config.cb_load_dir_up();}
@@ -776,7 +819,7 @@ cl_gts_master.cl_bro_level.cb_info_redisplay();}
     Fl_Window window_config_save_as {
       label {Save As Config}
       callback {cl_gts_master.cl_bro_config.cb_save_as_cancel();}
-      xywh {50 50 300 390} type Double resizable non_modal size_range {200 125 0 0} visible
+      xywh {-32000 -32000 300 390} type Double hide resizable non_modal size_range {200 125 0 0}
     } {
       Fl_Button {} {
         callback {cl_gts_master.cl_bro_config.cb_save_as_dir_up();}
@@ -840,7 +883,7 @@ cl_gts_master.cl_bro_level.cb_info_redisplay();}
       label {Area and Rot90}
       callback {cl_gts_gui.window_crop_area_and_rot90->hide();
 cl_gts_gui.menite_crop_area_and_rot90->clear();}
-      xywh {50 50 200 265} type Double non_modal visible
+      xywh {-32000 -32000 200 265} type Double hide non_modal
     } {
       Fl_Button {} {
         label Crop
@@ -1015,7 +1058,7 @@ cl_gts_master.cb_scan_full_area_and_crop();}
       label {Pixel Type and Bright}
       callback {cl_gts_gui.window_pixel_type_and_bright->hide();
 cl_gts_gui.menite_pixel_type_and_bright->clear();}
-      xywh {50 50 265 190} type Double resizable non_modal size_range {200 190 1000 190} visible
+      xywh {-32000 -32000 265 190} type Double hide resizable non_modal size_range {200 190 1000 190}
     } {
       Fl_Group {} {open
         xywh {0 5 265 25}
@@ -1176,7 +1219,7 @@ cl_gts_gui.window_edit_color->hide();
 cl_gts_gui.menite_edit_color->clear();
 cl_gts_gui.window_hab_histogram->hide();
 cl_gts_gui.menite_edit_hsv_min_max->clear();}
-      xywh {50 50 285 785} type Double non_modal visible
+      xywh {-32000 -32000 285 785} type Double hide non_modal
     } {
       Fl_Group {} {
         xywh {5 5 280 120}
@@ -1832,7 +1875,7 @@ cl_gts_master.cb_color_trace_src_redraw_image();}
       label Number
       callback {cl_gts_gui.window_fnum_list->hide();
 cl_gts_gui.menite_fnum_list->clear();}
-      xywh {50 50 116 350} type Double resizable non_modal visible
+      xywh {-32000 -32000 116 350} type Double hide resizable non_modal
     } {
       Fl_Menu_Bar {} {open
         xywh {0 0 116 25}
@@ -1868,7 +1911,7 @@ cl_gts_gui.menite_fnum_list->clear();}
     Fl_Window window_trace_batch {
       label {Color Trace Batch}
       callback {cl_gts_master.cl_bro_trace_batch.cb_cancel();}
-      xywh {50 50 300 415} type Double resizable non_modal size_range {200 125 0 0} visible
+      xywh {-32000 -32000 300 415} type Double hide resizable non_modal size_range {200 125 0 0}
     } {
       Fl_Button {} {
         callback {cl_gts_master.cl_bro_trace_batch.cb_dir_up();}
@@ -1968,7 +2011,7 @@ cl_gts_gui.window_edit_color->hide();
 cl_gts_gui.menite_edit_color->clear();
 cl_gts_gui.window_hab_histogram->hide();
 cl_gts_gui.menite_edit_hsv_min_max->clear();}
-      xywh {50 50 330 225} type Double resizable non_modal size_range {200 225 1000 225} visible
+      xywh {-32000 -32000 330 225} type Double hide resizable non_modal size_range {200 225 1000 225}
     } {
       Fl_Group {} {open
         xywh {0 15 330 20}
@@ -2245,7 +2288,7 @@ cl_gts_master.cb_color_trace_src_redraw_image();}
       label {Input Color(HSV Min Max)}
       callback {cl_gts_gui.window_hab_histogram->hide();
 cl_gts_gui.menite_edit_hsv_min_max->clear();}
-      xywh {50 50 1000 565} type Double non_modal visible
+      xywh {-32000 -32000 1000 565} type Double hide non_modal
     } {
       Fl_Menu_Bar {} {open
         xywh {0 0 1000 25}
@@ -2463,7 +2506,7 @@ fltkp_bb_histogram->redraw();}
       label {Output Color(RGB)}
       callback {cl_gts_gui.window_edit_color->hide();
 cl_gts_gui.menite_edit_color->clear();}
-      xywh {50 50 385 100} type Double resizable non_modal size_range {200 100 1000 100} visible
+      xywh {-32000 -32000 385 100} type Double hide resizable non_modal size_range {200 100 1000 100}
     } {
       Fl_Group {} {open
         xywh {0 10 385 20}
@@ -2523,6 +2566,271 @@ cl_gts_master.cl_color_trace_edit_color.cb_change_color();}
           callback {((Fl_Valuator *)scrbar_edit_color_blu)->value(o->value());
 cl_gts_master.cl_color_trace_edit_color.cb_change_color();}
           xywh {345 70 35 20} box BORDER_BOX maximum 255 step 1
+        }
+      }
+    }
+    Fl_Window tmp_window_level {
+      label {Browse Level}
+      callback {cl_gts_master.cl_bro_level.cb_cancel();} open
+      xywh {50 50 380 630} type Double resizable non_modal size_range {370 300 0 0} visible
+    } {
+      Fl_Button {} {
+        callback {cl_gts_master.cl_bro_level.cb_dir_up();}
+        xywh {0 0 0 0} shortcut 0x40075
+      }
+      Fl_File_Input filinp_level_dir {
+        label Directory
+        callback {cl_gts_master.cl_bro_level.cb_dir();}
+        xywh {0 20 380 35} box BORDER_BOX align 5 when 1
+      }
+      Fl_Group {} {open
+        xywh {0 60 380 25}
+      } {
+        Fl_Choice choice_level_list_form {
+          callback {cl_gts_master.cl_bro_level.cb_file_or_level();} open
+          xywh {5 60 80 25} down_box BORDER_BOX
+        } {
+          MenuItem {} {
+            label File
+            xywh {15 15 100 20}
+          }
+          MenuItem {} {
+            label Level
+            xywh {20 20 100 20}
+          }
+        }
+        Fl_Button {} {
+          label Makedir
+          callback {cl_gts_master.cl_bro_level.cb_mkdir();}
+          xywh {90 60 60 25}
+        }
+        Fl_Button {} {
+          label Rename
+          callback {cl_gts_master.cl_bro_level.cb_rename();}
+          xywh {155 60 60 25}
+        }
+        Fl_Button button_level_shift_number {
+          label {Shift number}
+          callback {cl_gts_master.cl_bro_level.cb_renumber();}
+          xywh {220 60 85 25} hide
+        }
+        Fl_Box {} {
+          xywh {305 60 10 25} resizable
+        }
+        Fl_Button {} {
+          label Explorer
+          callback {std::string comm("C:\\\\WINDOWS\\\\explorer.exe");
+\# ifdef _WIN32
+    comm += ' ';
+    comm += cl_gts_gui.filinp_level_dir->value();
+    //std::string comm("start "); comm += cl_gts_gui.filinp_level_dir->value();
+    for (unsigned ii = 0; ii < comm.size(); ++ii) {
+        if ('/' == comm[ii]) { comm[ii] = '\\\\'; }
+    }
+
+    STARTUPINFO si; ::ZeroMemory(&si,sizeof(si)); si.cb = sizeof(si);
+    PROCESS_INFORMATION pi;
+    if (!::CreateProcess(
+        NULL,(LPTSTR)comm.c_str(),NULL,NULL,FALSE,0,NULL,NULL,&si,&pi
+    )) {
+        std::cerr
+            << "Error : Cannot CreateProcess("
+            << comm
+            << ")\\n";
+        return;
+    }
+    ::CloseHandle(pi.hProcess);
+    ::CloseHandle(pi.hThread);
+\# endif}
+          xywh {315 60 60 25}
+          code0 {\#include <iostream>}
+        }
+      }
+      Fl_Tile {} {
+        xywh {0 90 380 330} align 0 resizable
+      } {
+        Fl_Group {} {open
+          xywh {0 90 150 330} box DOWN_BOX
+        } {
+          Fl_Browser selbro_level_list {
+            callback {cl_gts_master.cl_bro_level.cb_list();}
+            xywh {0 90 150 330} type Hold align 0
+          }
+        }
+        Fl_Group {} {open
+          xywh {150 90 230 150} box DOWN_BOX
+        } {
+          Fl_Box box_level_image {
+            xywh {150 90 230 150}
+          }
+        }
+        Fl_Group {} {open
+          xywh {150 240 230 180} box DOWN_BOX
+        } {
+          Fl_Text_Display txtdis_level_info {
+            xywh {150 240 230 155} color 50 align 4 resizable
+          }
+          Fl_Group {} {open
+            xywh {150 395 230 25}
+          } {
+            Fl_Scrollbar scroll_level_info_number {
+              callback {cl_gts_gui.valinp_level_crnt->value(
+cl_gts_gui.scroll_level_info_number->value()
+);
+cl_gts_master.cl_bro_level.cb_info_redisplay();}
+              xywh {150 395 190 25} type Horizontal box BORDER_BOX when 4 resizable
+            }
+            Fl_Value_Input valinp_level_crnt {
+              callback {((Fl_Valuator *)(cl_gts_gui.scroll_level_info_number))->value(
+(double)cl_gts_gui.valinp_level_crnt->value()
+);
+cl_gts_master.cl_bro_level.cb_info_redisplay();}
+              xywh {340 395 40 25} when 8 minimum 1 maximum 9999 value 1
+            }
+          }
+        }
+      }
+      Fl_Group {} {open
+        xywh {0 425 380 25}
+      } {
+        Fl_Box {} {
+          xywh {0 425 80 25}
+        }
+        Fl_Input strinp_level_file {
+          label Level
+          callback {cl_gts_master.cl_bro_level.cb_level_name();}
+          xywh {80 425 300 25} box BORDER_BOX when 1 resizable
+        }
+      }
+      Fl_Group {} {open
+        xywh {0 455 380 25}
+      } {
+        Fl_Value_Input valinp_level_start {
+          label Start
+          xywh {80 455 50 25} box BORDER_BOX minimum 1 maximum 9999 value 1
+        }
+        Fl_Box {} {
+          xywh {130 455 110 25} resizable
+        }
+        Fl_Light_Button ligbut_level_image_x1_sw {
+          label x1
+          callback {cl_gts_master.cl_bro_level.cb_x1view_wintgl();}
+          xywh {240 455 35 25}
+        }
+        Fl_Light_Button ligbut_level_view_sw {
+          label {View image}
+          callback {cl_gts_master.cl_bro_level.cb_info_redisplay();}
+          xywh {280 455 95 25}
+        }
+      }
+      Fl_Group {} {open
+        xywh {0 485 380 25}
+      } {
+        Fl_Choice choice_level_continue_type {
+          callback {if (o->value() == 0) {
+ cl_gts_gui.valinp_level_end->show();
+ cl_gts_gui.choice_level_endless_direction->hide();
+} else {
+ cl_gts_gui.valinp_level_end->hide();
+ cl_gts_gui.choice_level_endless_direction->show();
+}} open
+          xywh {0 485 80 25} down_box BORDER_BOX
+        } {
+          MenuItem {} {
+            label End
+            xywh {0 0 30 20}
+          }
+          MenuItem {} {
+            label Endless
+            xywh {0 0 30 20}
+          }
+        }
+        Fl_Choice choice_level_endless_direction {open
+          xywh {80 485 50 25} down_box BORDER_BOX
+        } {
+          MenuItem {} {
+            label {+1}
+            xywh {0 0 30 20}
+          }
+          MenuItem {} {
+            label {-1}
+            xywh {0 0 30 20}
+          }
+        }
+        Fl_Value_Input valinp_level_end {
+          xywh {80 485 50 25} box BORDER_BOX minimum 1 maximum 9999 value 1
+        }
+        Fl_Box {} {
+          xywh {130 485 250 25} resizable
+        }
+      }
+      Fl_Group {} {open
+        xywh {0 515 380 25}
+      } {
+        Fl_Choice choice_level_image_file_format {
+          label Format
+          callback {cl_gts_master.cl_bro_level.cb_set_image_file_extension();} open
+          xywh {80 515 65 25} down_box BORDER_BOX
+        } {
+          MenuItem {} {
+            label TIFF
+            xywh {0 0 30 20}
+          }
+          MenuItem {} {
+            label TGA
+            xywh {0 0 30 20}
+          }
+        }
+        Fl_Box {} {
+          xywh {145 515 235 25} resizable
+        }
+      }
+      Fl_Group {} {open
+        xywh {0 545 380 50}
+      } {
+        Fl_File_Input filinp_level_rgb_scan_dir {
+          label {RGB scan dir}
+          callback {cl_gts_master.cl_bro_level.cb_rgb_scan_dir();}
+          xywh {0 560 135 35} align 5 when 1 deactivate resizable
+        }
+        Fl_Check_Button chkbtn_level_rgb_trace_save_sw {
+          label {S.C.T.}
+          tooltip {Save Color Trace level} xywh {135 575 60 20} down_box DOWN_BOX
+        }
+        Fl_Check_Button chkbtn_level_rgb_full_save_sw {
+          label {S.Full}
+          tooltip {Save RGB Full  level} xywh {195 575 60 20} down_box DOWN_BOX value 1
+        }
+        Fl_Check_Button chkbtn_level_rgb_with_full_sw {
+          label With_full
+          tooltip {With _full in RGB full name} xywh {195 553 75 20} down_box DOWN_BOX value 1
+        }
+        Fl_Light_Button ligbut_level_rgb_scan_browse_sw {
+          label Browse
+          callback {cl_gts_master.cl_bro_level.cb_browse_sw();}
+          xywh {255 570 70 25}
+        }
+        Fl_Light_Button ligbut_level_info_rgb_sub_sw {
+          label Full
+          callback {cl_gts_master.cl_bro_level.cb_info_redisplay();}
+          xywh {325 570 50 25} hide
+        }
+      }
+      Fl_Group {} {open
+        xywh {0 600 380 24}
+      } {
+        Fl_Button {} {
+          label OK
+          callback {cl_gts_master.cl_bro_level.cb_ok();}
+          xywh {10 600 80 24}
+        }
+        Fl_Box {} {
+          xywh {90 600 200 24} resizable
+        }
+        Fl_Button {} {
+          label Cancel
+          callback {cl_gts_master.cl_bro_level.cb_cancel();}
+          xywh {290 600 80 24}
         }
       }
     }

--- a/sources/libcpp83gts_callback_and_action/gts_gui.fl
+++ b/sources/libcpp83gts_callback_and_action/gts_gui.fl
@@ -20,7 +20,7 @@ class gts_gui {open
     Fl_Window window_opengl {
       label GTS
       callback {cl_gts_master.cb_quit();}
-      xywh {-32000 -32000 720 565} type Double hide resizable
+      xywh {50 50 720 565} type Double resizable visible
     } {
       Fl_Menu_Bar {} {open
         xywh {0 0 720 25}
@@ -34,9 +34,9 @@ class gts_gui {open
             callback {if (cl_gts_gui.menite_level->value()) {
     cl_gts_master.cl_bro_level.cb_level_name();
     cl_gts_gui.window_opengl->show();/* Need for Minimize */
-    cl_gts_gui.window_level->show();
+    cl_gts_gui.window_level_set->show();
 } else {
-    cl_gts_gui.window_level->hide();
+    cl_gts_gui.window_level_set->hide();
 }}
             xywh {5 5 100 20} type Toggle shortcut 0xffbf divider
           }
@@ -406,7 +406,7 @@ fl_message( ost.str().c_str() );}
     }
     Fl_Window window_next_scan {
       label {Next Scan}
-      xywh {-32000 -32000 545 100} type Double hide modal
+      xywh {50 50 545 100} type Double modal visible
     } {
       Fl_Button button_rescan {
         label Rescan
@@ -434,79 +434,108 @@ fl_message( ost.str().c_str() );}
       }
     }
     Fl_Window window_level_set {
-      label Level open
-      xywh {-920 -220 200 425} type Double resizable non_modal size_range {200 360 1000 360} visible
+      label Level
+      callback {cl_gts_gui.window_level_set->hide();
+cl_gts_gui.menite_level->clear();}
+      xywh {50 50 200 430} type Double non_modal visible
     } {
       Fl_Group {} {open
-        xywh {0 0 200 235} box BORDER_BOX
+        xywh {0 0 385 240} box BORDER_BOX
       } {
-        Fl_Button ligbut_level_rgb_scan_browse_sw {
+        Fl_Button {} {
           label {Browse...}
-          callback {cl_gts_master.cl_bro_level.cb_browse_sw();}
-          xywh {5 5 190 25}
+          callback {cl_gts_gui.window_level_browse->show();}
+          xywh {115 5 80 25}
         }
         Fl_Group {} {open
-          xywh {0 30 200 170}
+          xywh {0 35 385 175}
         } {
           Fl_Group {} {open
-            xywh {0 30 200 50}
+            xywh {0 35 200 50}
           } {
             Fl_File_Input filinp_level_dir {
               label Directory
               callback {cl_gts_master.cl_bro_level.cb_dir();}
-              xywh {0 45 200 35} box BORDER_BOX align 5 when 1 resizable
+              xywh {0 50 200 35} box BORDER_BOX align 5 when 1
             }
           }
           Fl_Group {} {open
-            xywh {0 80 200 30}
+            xywh {0 85 200 30}
           } {
             Fl_Box {} {
-              xywh {0 85 50 25}
+              xywh {0 90 80 25}
             }
             Fl_Input strinp_level_file {
               label Level
               callback {cl_gts_master.cl_bro_level.cb_level_name();}
-              xywh {50 85 150 25} box BORDER_BOX when 1 resizable
+              xywh {80 90 120 25} box BORDER_BOX when 1
             }
           }
           Fl_Group {} {open
-            xywh {0 110 200 30}
+            xywh {0 115 200 30}
           } {
             Fl_Box {} {
-              xywh {0 115 50 25}
+              xywh {0 120 80 25}
             }
             Fl_Value_Input valinp_level_start {
               label Start
-              xywh {50 115 40 25} box BORDER_BOX minimum 1 maximum 9999 value 1
+              xywh {80 120 50 25} box BORDER_BOX minimum 1 maximum 9999 value 1
             }
             Fl_Box {} {
-              xywh {90 115 110 25} resizable
+              xywh {130 120 70 25}
             }
           }
           Fl_Group {} {open
-            xywh {0 140 200 30}
+            xywh {0 150 200 25}
           } {
-            Fl_Box {} {
-              xywh {0 145 50 25}
+            Fl_Choice choice_level_continue_type {
+              callback {if (o->value() == 0) {
+ cl_gts_gui.valinp_level_end->show();
+ cl_gts_gui.choice_level_endless_direction->hide();
+} else {
+ cl_gts_gui.valinp_level_end->hide();
+ cl_gts_gui.choice_level_endless_direction->show();
+}} open
+              xywh {0 150 80 25} down_box BORDER_BOX
+            } {
+              MenuItem {} {
+                label End
+                xywh {5 5 30 20}
+              }
+              MenuItem {} {
+                label Endless
+                xywh {5 5 30 20}
+              }
+            }
+            Fl_Choice choice_level_endless_direction {open
+              xywh {80 150 50 25} down_box BORDER_BOX
+            } {
+              MenuItem {} {
+                label {+1}
+                xywh {5 5 30 20}
+              }
+              MenuItem {} {
+                label {-1}
+                xywh {5 5 30 20}
+              }
             }
             Fl_Value_Input valinp_level_end {
-              label End
-              xywh {50 145 40 25} box BORDER_BOX minimum 1 maximum 9999 value 1
+              xywh {80 150 50 25} box BORDER_BOX minimum 1 maximum 9999 value 1
             }
             Fl_Box {} {
-              xywh {90 145 110 25} resizable
+              xywh {130 150 70 25}
             }
           }
           Fl_Group {} {open
-            xywh {0 170 200 30}
+            xywh {0 175 200 30}
           } {
             Fl_Box {} {
-              xywh {0 175 50 25}
+              xywh {0 180 80 25}
             }
             Fl_Choice choice_level_image_file_format {
               label Format
               callback {cl_gts_master.cl_bro_level.cb_set_image_file_extension();} open
-              xywh {50 175 100 25} down_box BORDER_BOX
+              xywh {80 180 100 25} down_box BORDER_BOX
             } {
               MenuItem {} {
                 label {TIFF(*.tif)}
@@ -518,69 +547,71 @@ fl_message( ost.str().c_str() );}
               }
             }
             Fl_Box {} {
-              xywh {150 175 50 25} resizable
+              xywh {180 180 20 25}
             }
           }
         }
         Fl_Button {} {
           label {Set Number}
           callback {cl_gts_master.cl_bro_level.cb_ok();}
-          xywh {5 205 190 25}
+          xywh {5 210 80 25}
         }
       }
       Fl_Group {} {
         label {Save RGB} open
-        xywh {0 240 200 140} box BORDER_BOX align 21
+        xywh {0 245 200 140} box BORDER_BOX align 21
       } {
         Fl_Check_Button chkbtn_level_rgb_trace_save_sw {
           label {Save Trace Image}
-          xywh {5 260 190 20} down_box DOWN_BOX resizable
+          xywh {5 265 190 20} down_box DOWN_BOX
         }
         Fl_Group {} {open
-          xywh {5 280 190 100}
+          xywh {5 285 190 100}
         } {
           Fl_Check_Button chkbtn_level_rgb_full_save_sw {
             label {Save Scan Image}
-            xywh {5 280 190 20} down_box DOWN_BOX value 1 resizable
+            xywh {5 285 190 20} down_box DOWN_BOX value 1
           }
           Fl_Group {} {open
-            xywh {10 300 180 75} box BORDER_BOX
+            xywh {10 305 180 75} box BORDER_BOX
           } {
             Fl_Group {} {open
-              xywh {15 300 170 55}
+              xywh {15 305 170 55}
             } {
               Fl_File_Input filinp_level_rgb_scan_dir {
                 label Directory
                 callback {cl_gts_master.cl_bro_level.cb_rgb_scan_dir();}
-                xywh {15 315 155 35} align 5 when 1 resizable
+                xywh {15 320 155 35} align 5 when 1
               }
-              Fl_Button {} {
+              Fl_Button ligbut_level_rgb_scan_browse_sw {
                 label {<}
-                xywh {170 325 15 25}
+                callback {cl_gts_master.cl_bro_level.cb_browse_sw();
+cl_gts_gui.window_level_browse->show();}
+                xywh {170 330 15 25} type Toggle
               }
             }
             Fl_Check_Button chkbtn_level_rgb_with_full_sw {
               label {Add _full in level}
-              xywh {15 355 175 20} down_box DOWN_BOX value 1 resizable
+              xywh {15 360 175 20} down_box DOWN_BOX value 1
             }
           }
         }
       }
       Fl_Group {} {
         label Filter open
-        xywh {0 385 200 40} box BORDER_BOX align 21
+        xywh {0 390 200 40} box BORDER_BOX align 21
       } {
         Fl_Check_Button chkbtn_color_trace_erase_1dot {
           label {Erase dot noise}
           callback {cl_gts_master.cb_real_time_on_off();}
-          xywh {5 400 190 25} down_box DOWN_BOX resizable
+          xywh {5 405 190 25} down_box DOWN_BOX
         }
       }
     }
     Fl_Window window_level_browse {
       label Browse
-      callback {cl_gts_master.cl_bro_level.cb_cancel();} open
-      xywh {-1330 -225 380 425} type Double resizable modal size_range {370 470 0 0} visible
+      callback {cl_gts_master.cl_bro_level.cb_cancel();}
+      xywh {50 50 380 425} type Double resizable modal size_range {180 120 1920 1200} visible
     } {
       Fl_Menu_Bar {} {open
         xywh {0 0 380 25}
@@ -601,7 +632,7 @@ fl_message( ost.str().c_str() );}
           }
           MenuItem button_level_shift_number {
             label {Shift Number...}
-            callback {cl_gts_master.cl_bro_level.cb_renumber();} selected
+            callback {cl_gts_master.cl_bro_level.cb_renumber();}
             xywh {0 0 30 20}
           }
           MenuItem {} {
@@ -640,7 +671,7 @@ fl_message( ost.str().c_str() );}
           MenuItem ligbut_level_view_sw {
             label Image
             callback {cl_gts_master.cl_bro_level.cb_info_redisplay();}
-            xywh {0 0 30 20} type Toggle
+            xywh {0 0 30 20} type Toggle value 1
           }
           MenuItem ligbut_level_info_rgb_sub_sw {
             label _full
@@ -650,7 +681,7 @@ fl_message( ost.str().c_str() );}
           MenuItem ligbut_level_image_x1_sw {
             label X1
             callback {cl_gts_master.cl_bro_level.cb_x1view_wintgl();}
-            xywh {0 0 30 20} type Toggle
+            xywh {0 0 30 20} type Toggle hide
           }
         }
       }
@@ -667,12 +698,12 @@ fl_message( ost.str().c_str() );}
           xywh {25 30 80 25} down_box BORDER_BOX
         } {
           MenuItem {} {
-            label Level
-            xywh {25 25 100 20}
-          }
-          MenuItem {} {
             label File
             xywh {20 20 100 20}
+          }
+          MenuItem {} {
+            label Level
+            xywh {25 25 100 20}
           }
         }
         Fl_Box {} {
@@ -727,7 +758,7 @@ cl_gts_master.cl_bro_level.cb_info_redisplay();}
         xywh {0 395 380 24}
       } {
         Fl_Button {} {
-          label OK
+          label Set
           callback {cl_gts_master.cl_bro_level.cb_ok();}
           xywh {10 395 80 24}
         }
@@ -744,7 +775,7 @@ cl_gts_master.cl_bro_level.cb_info_redisplay();}
     Fl_Window window_x1view {
       label x1
       callback {cl_gts_master.cl_bro_level.cb_x1view_cancel();}
-      xywh {-32000 -32000 300 300} type Double align 0 hide resizable non_modal
+      xywh {50 50 300 300} type Double align 0 resizable non_modal visible
     } {
       Fl_Scroll scroll_level_x1view {open
         xywh {0 0 300 300} align 0 resizable
@@ -757,7 +788,7 @@ cl_gts_master.cl_bro_level.cb_info_redisplay();}
     Fl_Window window_config_load {
       label {Load Config}
       callback {cl_gts_master.cl_bro_config.cb_load_cancel();}
-      xywh {-32000 -32000 300 390} type Double hide resizable non_modal size_range {200 125 0 0}
+      xywh {50 50 300 390} type Double resizable non_modal size_range {200 125 0 0} visible
     } {
       Fl_Button {} {
         callback {cl_gts_master.cl_bro_config.cb_load_dir_up();}
@@ -819,7 +850,7 @@ cl_gts_master.cl_bro_level.cb_info_redisplay();}
     Fl_Window window_config_save_as {
       label {Save As Config}
       callback {cl_gts_master.cl_bro_config.cb_save_as_cancel();}
-      xywh {-32000 -32000 300 390} type Double hide resizable non_modal size_range {200 125 0 0}
+      xywh {50 50 300 390} type Double resizable non_modal size_range {200 125 0 0} visible
     } {
       Fl_Button {} {
         callback {cl_gts_master.cl_bro_config.cb_save_as_dir_up();}
@@ -883,7 +914,7 @@ cl_gts_master.cl_bro_level.cb_info_redisplay();}
       label {Area and Rot90}
       callback {cl_gts_gui.window_crop_area_and_rot90->hide();
 cl_gts_gui.menite_crop_area_and_rot90->clear();}
-      xywh {-32000 -32000 200 265} type Double hide non_modal
+      xywh {50 50 200 265} type Double non_modal visible
     } {
       Fl_Button {} {
         label Crop
@@ -1058,7 +1089,7 @@ cl_gts_master.cb_scan_full_area_and_crop();}
       label {Pixel Type and Bright}
       callback {cl_gts_gui.window_pixel_type_and_bright->hide();
 cl_gts_gui.menite_pixel_type_and_bright->clear();}
-      xywh {-32000 -32000 265 190} type Double hide resizable non_modal size_range {200 190 1000 190}
+      xywh {50 50 265 190} type Double resizable non_modal size_range {200 190 1000 190} visible
     } {
       Fl_Group {} {open
         xywh {0 5 265 25}
@@ -1219,7 +1250,7 @@ cl_gts_gui.window_edit_color->hide();
 cl_gts_gui.menite_edit_color->clear();
 cl_gts_gui.window_hab_histogram->hide();
 cl_gts_gui.menite_edit_hsv_min_max->clear();}
-      xywh {-32000 -32000 285 785} type Double hide non_modal
+      xywh {50 50 285 755} type Double non_modal visible
     } {
       Fl_Group {} {
         xywh {5 5 280 120}
@@ -1845,10 +1876,10 @@ cl_gts_master.cb_color_trace_src_redraw_image();}
           }
         }
       }
-      Fl_Check_Button chkbtn_color_trace_erase_1dot {
+      Fl_Check_Button chkbtn_color_trace_erase_1dot__ {
         label {Erase dot noise}
         callback {cl_gts_master.cb_real_time_on_off();}
-        xywh {5 755 130 25} down_box DOWN_BOX
+        xywh {5 755 130 25} down_box DOWN_BOX hide
       }
       Fl_Check_Button menite_color_trace_real_time__ {
         label {Real Time}
@@ -1875,7 +1906,7 @@ cl_gts_master.cb_color_trace_src_redraw_image();}
       label Number
       callback {cl_gts_gui.window_fnum_list->hide();
 cl_gts_gui.menite_fnum_list->clear();}
-      xywh {-32000 -32000 116 350} type Double hide resizable non_modal
+      xywh {50 50 116 350} type Double resizable non_modal visible
     } {
       Fl_Menu_Bar {} {open
         xywh {0 0 116 25}
@@ -1911,7 +1942,7 @@ cl_gts_gui.menite_fnum_list->clear();}
     Fl_Window window_trace_batch {
       label {Color Trace Batch}
       callback {cl_gts_master.cl_bro_trace_batch.cb_cancel();}
-      xywh {-32000 -32000 300 415} type Double hide resizable non_modal size_range {200 125 0 0}
+      xywh {50 50 300 415} type Double resizable non_modal size_range {200 125 0 0} visible
     } {
       Fl_Button {} {
         callback {cl_gts_master.cl_bro_trace_batch.cb_dir_up();}
@@ -2011,7 +2042,7 @@ cl_gts_gui.window_edit_color->hide();
 cl_gts_gui.menite_edit_color->clear();
 cl_gts_gui.window_hab_histogram->hide();
 cl_gts_gui.menite_edit_hsv_min_max->clear();}
-      xywh {-32000 -32000 330 225} type Double hide resizable non_modal size_range {200 225 1000 225}
+      xywh {50 50 330 225} type Double resizable non_modal size_range {200 225 1000 225} visible
     } {
       Fl_Group {} {open
         xywh {0 15 330 20}
@@ -2288,7 +2319,7 @@ cl_gts_master.cb_color_trace_src_redraw_image();}
       label {Input Color(HSV Min Max)}
       callback {cl_gts_gui.window_hab_histogram->hide();
 cl_gts_gui.menite_edit_hsv_min_max->clear();}
-      xywh {-32000 -32000 1000 565} type Double hide non_modal
+      xywh {50 50 1000 565} type Double non_modal visible
     } {
       Fl_Menu_Bar {} {open
         xywh {0 0 1000 25}
@@ -2506,7 +2537,7 @@ fltkp_bb_histogram->redraw();}
       label {Output Color(RGB)}
       callback {cl_gts_gui.window_edit_color->hide();
 cl_gts_gui.menite_edit_color->clear();}
-      xywh {-32000 -32000 385 100} type Double hide resizable non_modal size_range {200 100 1000 100}
+      xywh {50 50 385 100} type Double resizable non_modal size_range {200 100 1000 100} visible
     } {
       Fl_Group {} {open
         xywh {0 10 385 20}
@@ -2566,271 +2597,6 @@ cl_gts_master.cl_color_trace_edit_color.cb_change_color();}
           callback {((Fl_Valuator *)scrbar_edit_color_blu)->value(o->value());
 cl_gts_master.cl_color_trace_edit_color.cb_change_color();}
           xywh {345 70 35 20} box BORDER_BOX maximum 255 step 1
-        }
-      }
-    }
-    Fl_Window tmp_window_level {
-      label {Browse Level}
-      callback {cl_gts_master.cl_bro_level.cb_cancel();} open
-      xywh {50 50 380 630} type Double resizable non_modal size_range {370 300 0 0} visible
-    } {
-      Fl_Button {} {
-        callback {cl_gts_master.cl_bro_level.cb_dir_up();}
-        xywh {0 0 0 0} shortcut 0x40075
-      }
-      Fl_File_Input filinp_level_dir {
-        label Directory
-        callback {cl_gts_master.cl_bro_level.cb_dir();}
-        xywh {0 20 380 35} box BORDER_BOX align 5 when 1
-      }
-      Fl_Group {} {open
-        xywh {0 60 380 25}
-      } {
-        Fl_Choice choice_level_list_form {
-          callback {cl_gts_master.cl_bro_level.cb_file_or_level();} open
-          xywh {5 60 80 25} down_box BORDER_BOX
-        } {
-          MenuItem {} {
-            label File
-            xywh {15 15 100 20}
-          }
-          MenuItem {} {
-            label Level
-            xywh {20 20 100 20}
-          }
-        }
-        Fl_Button {} {
-          label Makedir
-          callback {cl_gts_master.cl_bro_level.cb_mkdir();}
-          xywh {90 60 60 25}
-        }
-        Fl_Button {} {
-          label Rename
-          callback {cl_gts_master.cl_bro_level.cb_rename();}
-          xywh {155 60 60 25}
-        }
-        Fl_Button button_level_shift_number {
-          label {Shift number}
-          callback {cl_gts_master.cl_bro_level.cb_renumber();}
-          xywh {220 60 85 25} hide
-        }
-        Fl_Box {} {
-          xywh {305 60 10 25} resizable
-        }
-        Fl_Button {} {
-          label Explorer
-          callback {std::string comm("C:\\\\WINDOWS\\\\explorer.exe");
-\# ifdef _WIN32
-    comm += ' ';
-    comm += cl_gts_gui.filinp_level_dir->value();
-    //std::string comm("start "); comm += cl_gts_gui.filinp_level_dir->value();
-    for (unsigned ii = 0; ii < comm.size(); ++ii) {
-        if ('/' == comm[ii]) { comm[ii] = '\\\\'; }
-    }
-
-    STARTUPINFO si; ::ZeroMemory(&si,sizeof(si)); si.cb = sizeof(si);
-    PROCESS_INFORMATION pi;
-    if (!::CreateProcess(
-        NULL,(LPTSTR)comm.c_str(),NULL,NULL,FALSE,0,NULL,NULL,&si,&pi
-    )) {
-        std::cerr
-            << "Error : Cannot CreateProcess("
-            << comm
-            << ")\\n";
-        return;
-    }
-    ::CloseHandle(pi.hProcess);
-    ::CloseHandle(pi.hThread);
-\# endif}
-          xywh {315 60 60 25}
-          code0 {\#include <iostream>}
-        }
-      }
-      Fl_Tile {} {
-        xywh {0 90 380 330} align 0 resizable
-      } {
-        Fl_Group {} {open
-          xywh {0 90 150 330} box DOWN_BOX
-        } {
-          Fl_Browser selbro_level_list {
-            callback {cl_gts_master.cl_bro_level.cb_list();}
-            xywh {0 90 150 330} type Hold align 0
-          }
-        }
-        Fl_Group {} {open
-          xywh {150 90 230 150} box DOWN_BOX
-        } {
-          Fl_Box box_level_image {
-            xywh {150 90 230 150}
-          }
-        }
-        Fl_Group {} {open
-          xywh {150 240 230 180} box DOWN_BOX
-        } {
-          Fl_Text_Display txtdis_level_info {
-            xywh {150 240 230 155} color 50 align 4 resizable
-          }
-          Fl_Group {} {open
-            xywh {150 395 230 25}
-          } {
-            Fl_Scrollbar scroll_level_info_number {
-              callback {cl_gts_gui.valinp_level_crnt->value(
-cl_gts_gui.scroll_level_info_number->value()
-);
-cl_gts_master.cl_bro_level.cb_info_redisplay();}
-              xywh {150 395 190 25} type Horizontal box BORDER_BOX when 4 resizable
-            }
-            Fl_Value_Input valinp_level_crnt {
-              callback {((Fl_Valuator *)(cl_gts_gui.scroll_level_info_number))->value(
-(double)cl_gts_gui.valinp_level_crnt->value()
-);
-cl_gts_master.cl_bro_level.cb_info_redisplay();}
-              xywh {340 395 40 25} when 8 minimum 1 maximum 9999 value 1
-            }
-          }
-        }
-      }
-      Fl_Group {} {open
-        xywh {0 425 380 25}
-      } {
-        Fl_Box {} {
-          xywh {0 425 80 25}
-        }
-        Fl_Input strinp_level_file {
-          label Level
-          callback {cl_gts_master.cl_bro_level.cb_level_name();}
-          xywh {80 425 300 25} box BORDER_BOX when 1 resizable
-        }
-      }
-      Fl_Group {} {open
-        xywh {0 455 380 25}
-      } {
-        Fl_Value_Input valinp_level_start {
-          label Start
-          xywh {80 455 50 25} box BORDER_BOX minimum 1 maximum 9999 value 1
-        }
-        Fl_Box {} {
-          xywh {130 455 110 25} resizable
-        }
-        Fl_Light_Button ligbut_level_image_x1_sw {
-          label x1
-          callback {cl_gts_master.cl_bro_level.cb_x1view_wintgl();}
-          xywh {240 455 35 25}
-        }
-        Fl_Light_Button ligbut_level_view_sw {
-          label {View image}
-          callback {cl_gts_master.cl_bro_level.cb_info_redisplay();}
-          xywh {280 455 95 25}
-        }
-      }
-      Fl_Group {} {open
-        xywh {0 485 380 25}
-      } {
-        Fl_Choice choice_level_continue_type {
-          callback {if (o->value() == 0) {
- cl_gts_gui.valinp_level_end->show();
- cl_gts_gui.choice_level_endless_direction->hide();
-} else {
- cl_gts_gui.valinp_level_end->hide();
- cl_gts_gui.choice_level_endless_direction->show();
-}} open
-          xywh {0 485 80 25} down_box BORDER_BOX
-        } {
-          MenuItem {} {
-            label End
-            xywh {0 0 30 20}
-          }
-          MenuItem {} {
-            label Endless
-            xywh {0 0 30 20}
-          }
-        }
-        Fl_Choice choice_level_endless_direction {open
-          xywh {80 485 50 25} down_box BORDER_BOX
-        } {
-          MenuItem {} {
-            label {+1}
-            xywh {0 0 30 20}
-          }
-          MenuItem {} {
-            label {-1}
-            xywh {0 0 30 20}
-          }
-        }
-        Fl_Value_Input valinp_level_end {
-          xywh {80 485 50 25} box BORDER_BOX minimum 1 maximum 9999 value 1
-        }
-        Fl_Box {} {
-          xywh {130 485 250 25} resizable
-        }
-      }
-      Fl_Group {} {open
-        xywh {0 515 380 25}
-      } {
-        Fl_Choice choice_level_image_file_format {
-          label Format
-          callback {cl_gts_master.cl_bro_level.cb_set_image_file_extension();} open
-          xywh {80 515 65 25} down_box BORDER_BOX
-        } {
-          MenuItem {} {
-            label TIFF
-            xywh {0 0 30 20}
-          }
-          MenuItem {} {
-            label TGA
-            xywh {0 0 30 20}
-          }
-        }
-        Fl_Box {} {
-          xywh {145 515 235 25} resizable
-        }
-      }
-      Fl_Group {} {open
-        xywh {0 545 380 50}
-      } {
-        Fl_File_Input filinp_level_rgb_scan_dir {
-          label {RGB scan dir}
-          callback {cl_gts_master.cl_bro_level.cb_rgb_scan_dir();}
-          xywh {0 560 135 35} align 5 when 1 deactivate resizable
-        }
-        Fl_Check_Button chkbtn_level_rgb_trace_save_sw {
-          label {S.C.T.}
-          tooltip {Save Color Trace level} xywh {135 575 60 20} down_box DOWN_BOX
-        }
-        Fl_Check_Button chkbtn_level_rgb_full_save_sw {
-          label {S.Full}
-          tooltip {Save RGB Full  level} xywh {195 575 60 20} down_box DOWN_BOX value 1
-        }
-        Fl_Check_Button chkbtn_level_rgb_with_full_sw {
-          label With_full
-          tooltip {With _full in RGB full name} xywh {195 553 75 20} down_box DOWN_BOX value 1
-        }
-        Fl_Light_Button ligbut_level_rgb_scan_browse_sw {
-          label Browse
-          callback {cl_gts_master.cl_bro_level.cb_browse_sw();}
-          xywh {255 570 70 25}
-        }
-        Fl_Light_Button ligbut_level_info_rgb_sub_sw {
-          label Full
-          callback {cl_gts_master.cl_bro_level.cb_info_redisplay();}
-          xywh {325 570 50 25} hide
-        }
-      }
-      Fl_Group {} {open
-        xywh {0 600 380 24}
-      } {
-        Fl_Button {} {
-          label OK
-          callback {cl_gts_master.cl_bro_level.cb_ok();}
-          xywh {10 600 80 24}
-        }
-        Fl_Box {} {
-          xywh {90 600 200 24} resizable
-        }
-        Fl_Button {} {
-          label Cancel
-          callback {cl_gts_master.cl_bro_level.cb_cancel();}
-          xywh {290 600 80 24}
         }
       }
     }

--- a/sources/libcpp83gts_callback_and_action/gts_gui.h
+++ b/sources/libcpp83gts_callback_and_action/gts_gui.h
@@ -251,10 +251,10 @@ private:
   inline void cb_filinp_level_rgb_scan_dir_i(Fl_File_Input*, void*);
   static void cb_filinp_level_rgb_scan_dir(Fl_File_Input*, void*);
 public:
-  Fl_Button *ligbut_level_rgb_scan_browse_sw;
+  Fl_Button *togbut_level_rgb_scan_browse_sw;
 private:
-  inline void cb_ligbut_level_rgb_scan_browse_sw_i(Fl_Button*, void*);
-  static void cb_ligbut_level_rgb_scan_browse_sw(Fl_Button*, void*);
+  inline void cb_togbut_level_rgb_scan_browse_sw_i(Fl_Button*, void*);
+  static void cb_togbut_level_rgb_scan_browse_sw(Fl_Button*, void*);
 public:
   Fl_Check_Button *chkbtn_level_rgb_with_full_sw;
   Fl_Check_Button *chkbtn_color_trace_erase_1dot;
@@ -272,27 +272,27 @@ private:
   inline void cb_Rename_i(Fl_Menu_*, void*);
   static void cb_Rename(Fl_Menu_*, void*);
 public:
-  static Fl_Menu_Item *button_level_shift_number;
+  static Fl_Menu_Item *menite_level_shift_number;
 private:
-  inline void cb_button_level_shift_number_i(Fl_Menu_*, void*);
-  static void cb_button_level_shift_number(Fl_Menu_*, void*);
+  inline void cb_menite_level_shift_number_i(Fl_Menu_*, void*);
+  static void cb_menite_level_shift_number(Fl_Menu_*, void*);
   inline void cb_Explorer_i(Fl_Menu_*, void*);
   static void cb_Explorer(Fl_Menu_*, void*);
 public:
-  static Fl_Menu_Item *ligbut_level_view_sw;
+  static Fl_Menu_Item *menite_level_view_sw;
 private:
-  inline void cb_ligbut_level_view_sw_i(Fl_Menu_*, void*);
-  static void cb_ligbut_level_view_sw(Fl_Menu_*, void*);
+  inline void cb_menite_level_view_sw_i(Fl_Menu_*, void*);
+  static void cb_menite_level_view_sw(Fl_Menu_*, void*);
 public:
-  static Fl_Menu_Item *ligbut_level_info_rgb_sub_sw;
+  static Fl_Menu_Item *menite_level_view_rgb_full_sw;
 private:
-  inline void cb_ligbut_level_info_rgb_sub_sw_i(Fl_Menu_*, void*);
-  static void cb_ligbut_level_info_rgb_sub_sw(Fl_Menu_*, void*);
+  inline void cb_menite_level_view_rgb_full_sw_i(Fl_Menu_*, void*);
+  static void cb_menite_level_view_rgb_full_sw(Fl_Menu_*, void*);
 public:
-  static Fl_Menu_Item *ligbut_level_image_x1_sw;
+  static Fl_Menu_Item *menite_level_image_x1_sw;
 private:
-  inline void cb_ligbut_level_image_x1_sw_i(Fl_Menu_*, void*);
-  static void cb_ligbut_level_image_x1_sw(Fl_Menu_*, void*);
+  inline void cb_menite_level_image_x1_sw_i(Fl_Menu_*, void*);
+  static void cb_menite_level_image_x1_sw(Fl_Menu_*, void*);
   inline void cb__i(Fl_Button*, void*);
   static void cb_(Fl_Button*, void*);
 public:

--- a/sources/libcpp83gts_callback_and_action/gts_gui.h
+++ b/sources/libcpp83gts_callback_and_action/gts_gui.h
@@ -9,23 +9,23 @@
 #include <FL/Fl_Scrollbar.H>
 #include <FL/Fl_Button.H>
 #include <FL/Fl_Output.H>
-#include <FL/Fl_File_Input.H>
 #include <FL/Fl_Group.H>
-#include <FL/Fl_Choice.H>
+#include <FL/Fl_File_Input.H>
 #include <FL/Fl_Box.H>
+#include <FL/Fl_Input.H>
+#include <FL/Fl_Value_Input.H>
+#include <FL/Fl_Choice.H>
+#include <FL/Fl_Check_Button.H>
 #include <iostream>
 #include <FL/Fl_Tile.H>
 #include <FL/Fl_Browser.H>
 #include <FL/Fl_Text_Display.H>
-#include <FL/Fl_Value_Input.H>
-#include <FL/Fl_Input.H>
-#include <FL/Fl_Light_Button.H>
-#include <FL/Fl_Check_Button.H>
 #include <FL/Fl_Scroll.H>
 #include <FL/Fl_Value_Output.H>
 #include <FL/Fl_Round_Button.H>
 #include "fltk_1000x100_histogram.h"
 #include "fltk_1000_range_cyclic.h"
+#include <FL/Fl_Light_Button.H>
 #include "fltk_1000x10_color_belt.h"
 #include "fltk_1000_range_minmax.h"
 
@@ -209,34 +209,98 @@ public:
   Fl_Output *norout_crnt_scan_level;
   Fl_Output *norout_crnt_scan_number;
   Fl_Output *norout_next_scan_number;
-  Fl_Double_Window *window_level;
+  Fl_Double_Window *window_level_set;
 private:
-  inline void cb_window_level_i(Fl_Double_Window*, void*);
-  static void cb_window_level(Fl_Double_Window*, void*);
-  inline void cb__i(Fl_Button*, void*);
-  static void cb_(Fl_Button*, void*);
+  inline void cb_window_level_set_i(Fl_Double_Window*, void*);
+  static void cb_window_level_set(Fl_Double_Window*, void*);
+  inline void cb_Browse_i(Fl_Button*, void*);
+  static void cb_Browse(Fl_Button*, void*);
 public:
   Fl_File_Input *filinp_level_dir;
 private:
   inline void cb_filinp_level_dir_i(Fl_File_Input*, void*);
   static void cb_filinp_level_dir(Fl_File_Input*, void*);
 public:
+  Fl_Input *strinp_level_file;
+private:
+  inline void cb_strinp_level_file_i(Fl_Input*, void*);
+  static void cb_strinp_level_file(Fl_Input*, void*);
+public:
+  Fl_Value_Input *valinp_level_start;
+  Fl_Choice *choice_level_continue_type;
+private:
+  inline void cb_choice_level_continue_type_i(Fl_Choice*, void*);
+  static void cb_choice_level_continue_type(Fl_Choice*, void*);
+  static Fl_Menu_Item menu_choice_level_continue_type[];
+public:
+  Fl_Choice *choice_level_endless_direction;
+  static Fl_Menu_Item menu_choice_level_endless_direction[];
+  Fl_Value_Input *valinp_level_end;
+  Fl_Choice *choice_level_image_file_format;
+private:
+  inline void cb_choice_level_image_file_format_i(Fl_Choice*, void*);
+  static void cb_choice_level_image_file_format(Fl_Choice*, void*);
+  static Fl_Menu_Item menu_choice_level_image_file_format[];
+  inline void cb_Set_i(Fl_Button*, void*);
+  static void cb_Set(Fl_Button*, void*);
+public:
+  Fl_Check_Button *chkbtn_level_rgb_trace_save_sw;
+  Fl_Check_Button *chkbtn_level_rgb_full_save_sw;
+  Fl_File_Input *filinp_level_rgb_scan_dir;
+private:
+  inline void cb_filinp_level_rgb_scan_dir_i(Fl_File_Input*, void*);
+  static void cb_filinp_level_rgb_scan_dir(Fl_File_Input*, void*);
+public:
+  Fl_Button *ligbut_level_rgb_scan_browse_sw;
+private:
+  inline void cb_ligbut_level_rgb_scan_browse_sw_i(Fl_Button*, void*);
+  static void cb_ligbut_level_rgb_scan_browse_sw(Fl_Button*, void*);
+public:
+  Fl_Check_Button *chkbtn_level_rgb_with_full_sw;
+  Fl_Check_Button *chkbtn_color_trace_erase_1dot;
+private:
+  inline void cb_chkbtn_color_trace_erase_1dot_i(Fl_Check_Button*, void*);
+  static void cb_chkbtn_color_trace_erase_1dot(Fl_Check_Button*, void*);
+public:
+  Fl_Double_Window *window_level_browse;
+private:
+  inline void cb_window_level_browse_i(Fl_Double_Window*, void*);
+  static void cb_window_level_browse(Fl_Double_Window*, void*);
+  static Fl_Menu_Item menu_1[];
+  inline void cb_Make_i(Fl_Menu_*, void*);
+  static void cb_Make(Fl_Menu_*, void*);
+  inline void cb_Rename_i(Fl_Menu_*, void*);
+  static void cb_Rename(Fl_Menu_*, void*);
+public:
+  static Fl_Menu_Item *button_level_shift_number;
+private:
+  inline void cb_button_level_shift_number_i(Fl_Menu_*, void*);
+  static void cb_button_level_shift_number(Fl_Menu_*, void*);
+  inline void cb_Explorer_i(Fl_Menu_*, void*);
+  static void cb_Explorer(Fl_Menu_*, void*);
+public:
+  static Fl_Menu_Item *ligbut_level_view_sw;
+private:
+  inline void cb_ligbut_level_view_sw_i(Fl_Menu_*, void*);
+  static void cb_ligbut_level_view_sw(Fl_Menu_*, void*);
+public:
+  static Fl_Menu_Item *ligbut_level_info_rgb_sub_sw;
+private:
+  inline void cb_ligbut_level_info_rgb_sub_sw_i(Fl_Menu_*, void*);
+  static void cb_ligbut_level_info_rgb_sub_sw(Fl_Menu_*, void*);
+public:
+  static Fl_Menu_Item *ligbut_level_image_x1_sw;
+private:
+  inline void cb_ligbut_level_image_x1_sw_i(Fl_Menu_*, void*);
+  static void cb_ligbut_level_image_x1_sw(Fl_Menu_*, void*);
+  inline void cb__i(Fl_Button*, void*);
+  static void cb_(Fl_Button*, void*);
+public:
   Fl_Choice *choice_level_list_form;
 private:
   inline void cb_choice_level_list_form_i(Fl_Choice*, void*);
   static void cb_choice_level_list_form(Fl_Choice*, void*);
   static Fl_Menu_Item menu_choice_level_list_form[];
-  inline void cb_Makedir_i(Fl_Button*, void*);
-  static void cb_Makedir(Fl_Button*, void*);
-  inline void cb_Rename_i(Fl_Button*, void*);
-  static void cb_Rename(Fl_Button*, void*);
-public:
-  Fl_Button *button_level_shift_number;
-private:
-  inline void cb_button_level_shift_number_i(Fl_Button*, void*);
-  static void cb_button_level_shift_number(Fl_Button*, void*);
-  inline void cb_Explorer_i(Fl_Button*, void*);
-  static void cb_Explorer(Fl_Button*, void*);
 public:
   Fl_Browser *selbro_level_list;
 private:
@@ -254,57 +318,8 @@ public:
 private:
   inline void cb_valinp_level_crnt_i(Fl_Value_Input*, void*);
   static void cb_valinp_level_crnt(Fl_Value_Input*, void*);
-public:
-  Fl_Input *strinp_level_file;
-private:
-  inline void cb_strinp_level_file_i(Fl_Input*, void*);
-  static void cb_strinp_level_file(Fl_Input*, void*);
-public:
-  Fl_Value_Input *valinp_level_start;
-  Fl_Light_Button *ligbut_level_image_x1_sw;
-private:
-  inline void cb_ligbut_level_image_x1_sw_i(Fl_Light_Button*, void*);
-  static void cb_ligbut_level_image_x1_sw(Fl_Light_Button*, void*);
-public:
-  Fl_Light_Button *ligbut_level_view_sw;
-private:
-  inline void cb_ligbut_level_view_sw_i(Fl_Light_Button*, void*);
-  static void cb_ligbut_level_view_sw(Fl_Light_Button*, void*);
-public:
-  Fl_Choice *choice_level_continue_type;
-private:
-  inline void cb_choice_level_continue_type_i(Fl_Choice*, void*);
-  static void cb_choice_level_continue_type(Fl_Choice*, void*);
-  static Fl_Menu_Item menu_choice_level_continue_type[];
-public:
-  Fl_Choice *choice_level_endless_direction;
-  static Fl_Menu_Item menu_choice_level_endless_direction[];
-  Fl_Value_Input *valinp_level_end;
-  Fl_Choice *choice_level_image_file_format;
-private:
-  inline void cb_choice_level_image_file_format_i(Fl_Choice*, void*);
-  static void cb_choice_level_image_file_format(Fl_Choice*, void*);
-  static Fl_Menu_Item menu_choice_level_image_file_format[];
-public:
-  Fl_File_Input *filinp_level_rgb_scan_dir;
-private:
-  inline void cb_filinp_level_rgb_scan_dir_i(Fl_File_Input*, void*);
-  static void cb_filinp_level_rgb_scan_dir(Fl_File_Input*, void*);
-public:
-  Fl_Check_Button *chkbtn_level_rgb_trace_save_sw;
-  Fl_Check_Button *chkbtn_level_rgb_full_save_sw;
-  Fl_Check_Button *chkbtn_level_rgb_with_full_sw;
-  Fl_Light_Button *ligbut_level_rgb_scan_browse_sw;
-private:
-  inline void cb_ligbut_level_rgb_scan_browse_sw_i(Fl_Light_Button*, void*);
-  static void cb_ligbut_level_rgb_scan_browse_sw(Fl_Light_Button*, void*);
-public:
-  Fl_Light_Button *ligbut_level_info_rgb_sub_sw;
-private:
-  inline void cb_ligbut_level_info_rgb_sub_sw_i(Fl_Light_Button*, void*);
-  static void cb_ligbut_level_info_rgb_sub_sw(Fl_Light_Button*, void*);
-  inline void cb_OK_i(Fl_Button*, void*);
-  static void cb_OK(Fl_Button*, void*);
+  inline void cb_Set1_i(Fl_Button*, void*);
+  static void cb_Set1(Fl_Button*, void*);
   inline void cb_Cancel_i(Fl_Button*, void*);
   static void cb_Cancel(Fl_Button*, void*);
 public:
@@ -980,10 +995,10 @@ private:
   inline void cb_button_color_trace_06_src_i(Fl_Button*, void*);
   static void cb_button_color_trace_06_src(Fl_Button*, void*);
 public:
-  Fl_Check_Button *chkbtn_color_trace_erase_1dot;
+  Fl_Check_Button *chkbtn_color_trace_erase_1dot__;
 private:
-  inline void cb_chkbtn_color_trace_erase_1dot_i(Fl_Check_Button*, void*);
-  static void cb_chkbtn_color_trace_erase_1dot(Fl_Check_Button*, void*);
+  inline void cb_chkbtn_color_trace_erase_1dot___i(Fl_Check_Button*, void*);
+  static void cb_chkbtn_color_trace_erase_1dot__(Fl_Check_Button*, void*);
 public:
   Fl_Check_Button *menite_color_trace_real_time__;
 private:
@@ -1000,7 +1015,7 @@ public:
 private:
   inline void cb_window_fnum_list_i(Fl_Double_Window*, void*);
   static void cb_window_fnum_list(Fl_Double_Window*, void*);
-  static Fl_Menu_Item menu_1[];
+  static Fl_Menu_Item menu_2[];
   inline void cb_Select_i(Fl_Menu_*, void*);
   static void cb_Select(Fl_Menu_*, void*);
   inline void cb_Delete_i(Fl_Menu_*, void*);
@@ -1023,7 +1038,7 @@ private:
   static void cb_window_trace_batch(Fl_Double_Window*, void*);
   inline void cb_3_i(Fl_Button*, void*);
   static void cb_3(Fl_Button*, void*);
-  static Fl_Menu_Item menu_2[];
+  static Fl_Menu_Item menu_3[];
   inline void cb_Add_i(Fl_Menu_*, void*);
   static void cb_Add(Fl_Menu_*, void*);
   inline void cb_All3_i(Fl_Menu_*, void*);
@@ -1246,7 +1261,7 @@ public:
 private:
   inline void cb_window_hab_histogram_i(Fl_Double_Window*, void*);
   static void cb_window_hab_histogram(Fl_Double_Window*, void*);
-  static Fl_Menu_Item menu_3[];
+  static Fl_Menu_Item menu_4[];
 public:
   static Fl_Menu_Item *menite_limit_nothing;
 private:

--- a/sources/libcpp83gts_callback_and_action/iipg_color_trace.cpp
+++ b/sources/libcpp83gts_callback_and_action/iipg_color_trace.cpp
@@ -120,6 +120,5 @@ void gts_master::_iipg_color_trace_exec( int i_area_sw )
 	/* erase dot noise */
 	if (cl_gts_gui.chkbtn_color_trace_erase_1dot->value()) {
 		this->cl_iip_edot.exec();
-		this->cl_iip_edot.exec();
 	}
 }

--- a/sources/libcpp83gts_callback_and_action/memory_config_load.cpp
+++ b/sources/libcpp83gts_callback_and_action/memory_config_load.cpp
@@ -92,11 +92,11 @@ std::cout << std::endl;
 		 i_level_list_redisplay_sw = ON;
 		 /* File/Level表示によってボタンを表示/非表示する */
 		 if (0 == cl_gts_gui.choice_level_list_form->value()) {
-			cl_gts_gui.button_level_shift_number->hide();
-			cl_gts_gui.ligbut_level_info_rgb_sub_sw->hide();
+			cl_gts_gui.button_level_shift_number->deactivate();
+			cl_gts_gui.ligbut_level_info_rgb_sub_sw->deactivate();
 		 } else {
-			cl_gts_gui.button_level_shift_number->show();
-			cl_gts_gui.ligbut_level_info_rgb_sub_sw->show();
+			cl_gts_gui.button_level_shift_number->activate();
+			cl_gts_gui.ligbut_level_info_rgb_sub_sw->activate();
 		 }
 	}
 	else {
@@ -107,11 +107,11 @@ std::cout << std::endl;
 		 i_level_list_redisplay_sw = ON;
 		 /* File/Level表示によってボタンを表示/非表示する */
 		 if (0 == cl_gts_gui.choice_level_list_form->value()) {
-			cl_gts_gui.button_level_shift_number->hide();
-			cl_gts_gui.ligbut_level_info_rgb_sub_sw->hide();
+			cl_gts_gui.button_level_shift_number->deactivate();
+			cl_gts_gui.ligbut_level_info_rgb_sub_sw->deactivate();
 		 } else {
-			cl_gts_gui.button_level_shift_number->show();
-			cl_gts_gui.ligbut_level_info_rgb_sub_sw->show();
+			cl_gts_gui.button_level_shift_number->activate();
+			cl_gts_gui.ligbut_level_info_rgb_sub_sw->activate();
 		 }
 		}
 	}

--- a/sources/libcpp83gts_callback_and_action/memory_config_load.cpp
+++ b/sources/libcpp83gts_callback_and_action/memory_config_load.cpp
@@ -92,11 +92,11 @@ std::cout << std::endl;
 		 i_level_list_redisplay_sw = ON;
 		 /* File/Level表示によってボタンを表示/非表示する */
 		 if (0 == cl_gts_gui.choice_level_list_form->value()) {
-			cl_gts_gui.button_level_shift_number->deactivate();
-			cl_gts_gui.ligbut_level_info_rgb_sub_sw->deactivate();
+			cl_gts_gui.menite_level_shift_number->deactivate();
+			cl_gts_gui.menite_level_view_rgb_full_sw->deactivate();
 		 } else {
-			cl_gts_gui.button_level_shift_number->activate();
-			cl_gts_gui.ligbut_level_info_rgb_sub_sw->activate();
+			cl_gts_gui.menite_level_shift_number->activate();
+			cl_gts_gui.menite_level_view_rgb_full_sw->activate();
 		 }
 	}
 	else {
@@ -107,11 +107,11 @@ std::cout << std::endl;
 		 i_level_list_redisplay_sw = ON;
 		 /* File/Level表示によってボタンを表示/非表示する */
 		 if (0 == cl_gts_gui.choice_level_list_form->value()) {
-			cl_gts_gui.button_level_shift_number->deactivate();
-			cl_gts_gui.ligbut_level_info_rgb_sub_sw->deactivate();
+			cl_gts_gui.menite_level_shift_number->deactivate();
+			cl_gts_gui.menite_level_view_rgb_full_sw->deactivate();
 		 } else {
-			cl_gts_gui.button_level_shift_number->activate();
-			cl_gts_gui.ligbut_level_info_rgb_sub_sw->activate();
+			cl_gts_gui.menite_level_shift_number->activate();
+			cl_gts_gui.menite_level_view_rgb_full_sw->activate();
 		 }
 		}
 	}

--- a/sources/libcpp83gts_callback_and_action/memory_desktop.h
+++ b/sources/libcpp83gts_callback_and_action/memory_desktop.h
@@ -24,6 +24,8 @@ public:
 
 	,str_window_level_(
 	    "window_level" )
+	,str_window_level_browse_(
+	    "window_level_browse" )
 	,str_window_config_load_(
 	    "window_config_load" )
 	,str_window_config_save_as_(
@@ -76,6 +78,7 @@ private:
 	const char* str_window_next_scan_;
 
 	const char* str_window_level_;
+	const char* str_window_level_browse_;
 	const char* str_window_config_load_;
 	const char* str_window_config_save_as_;
 

--- a/sources/libcpp83gts_callback_and_action/memory_desktop_load.cpp
+++ b/sources/libcpp83gts_callback_and_action/memory_desktop_load.cpp
@@ -115,6 +115,10 @@ int memory_desktop::load( void ) {
 			}
 		cl_gts_gui.window_level_set->position(xx,yy);
 		}
+		else if ((this->str_window_level_browse_==key)
+		&& (6==ret)) {
+		cl_gts_gui.window_level_browse->resize(xx,yy,ww,hh);
+		}
 		else if ((this->str_window_config_load_==key) && (6==ret)) {
 			if (di == "show") {
 		cl_gts_gui.menite_config_load->set();

--- a/sources/libcpp83gts_callback_and_action/memory_desktop_load.cpp
+++ b/sources/libcpp83gts_callback_and_action/memory_desktop_load.cpp
@@ -106,13 +106,14 @@ int memory_desktop::load( void ) {
 			}
 		cl_gts_gui.window_next_scan->position(xx,yy);
 		}
-		else if ((this->str_window_level_==key) && (6==ret)) {
+		else if ((this->str_window_level_==key)
+		&& ((4==ret) || (6==ret)/* for old format */)) {
 			if (di == "show") {
 		cl_gts_gui.menite_level->set();
 		cl_gts_gui.window_opengl->show();/* Need for Minimize */
-		cl_gts_gui.window_level->show();
+		cl_gts_gui.window_level_set->show();
 			}
-		cl_gts_gui.window_level->resize(xx,yy,ww,hh);
+		cl_gts_gui.window_level_set->position(xx,yy);
 		}
 		else if ((this->str_window_config_load_==key) && (6==ret)) {
 			if (di == "show") {

--- a/sources/libcpp83gts_callback_and_action/memory_desktop_save.cpp
+++ b/sources/libcpp83gts_callback_and_action/memory_desktop_save.cpp
@@ -41,6 +41,16 @@ int memory_desktop::_save_by_fp( FILE *fp )
 	if (i_ret < 0) { return NG; }
 
 	i_ret = fprintf(fp, "%-28s %s %d %d %d %d\n"
+	, this->str_window_level_browse_
+	, ccp_hide
+	, cl_gts_gui.window_level_browse->x()
+	, cl_gts_gui.window_level_browse->y()
+	, cl_gts_gui.window_level_browse->w()
+	, cl_gts_gui.window_level_browse->h()
+	);
+	if (i_ret < 0) { return NG; }
+
+	i_ret = fprintf(fp, "%-28s %s %d %d %d %d\n"
 	, this->str_window_config_load_
 	, cl_gts_gui.menite_config_load->value()?ccp_show:ccp_hide
 	, cl_gts_gui.window_config_load->x()

--- a/sources/libcpp83gts_callback_and_action/memory_desktop_save.cpp
+++ b/sources/libcpp83gts_callback_and_action/memory_desktop_save.cpp
@@ -32,13 +32,11 @@ int memory_desktop::_save_by_fp( FILE *fp )
 	);
 	if (i_ret < 0) { return NG; }
 
-	i_ret = fprintf(fp, "%-28s %s %d %d %d %d\n"
+	i_ret = fprintf(fp, "%-28s %s %d %d\n"
 	, this->str_window_level_
 	, cl_gts_gui.menite_level->value()?ccp_show:ccp_hide
-	, cl_gts_gui.window_level->x()
-	, cl_gts_gui.window_level->y()
-	, cl_gts_gui.window_level->w()
-	, cl_gts_gui.window_level->h()
+	, cl_gts_gui.window_level_set->x()
+	, cl_gts_gui.window_level_set->y()
 	);
 	if (i_ret < 0) { return NG; }
 

--- a/sources/main/main.cpp
+++ b/sources/main/main.cpp
@@ -76,7 +76,7 @@ static int argument_analyzer( int argc, char *argv[], char *cp_comm, gts_master 
 # ifdef PACKAGE_NAME
 gts_master cl_gts_master(PACKAGE_NAME, PACKAGE_VERSION, CONFIGURATION_DATE);
 # else
-gts_master cl_gts_master( "gts" ,"2.3.0" ,"2016-9-26" );
+gts_master cl_gts_master( "gts" ,"2.3.0" ,"2016-9-29" );
 # endif
 
 int main( int argc, char **argv )


### PR DESCRIPTION
#55 
### "Level"ウインドウを"Level"ウインドウと"Level Browse"ウインドウの二つに分離
- "Level"ウインドウは画面上に表示状態にしておくことができます
- "Level Browse"ウインドウはモーダルダイオローグです。必要な時だけ開いて使います。閉じないと他の操作はできません

いままでとの変更事項
- Color Trace EnhancementウインドウのErase dot noiseボタンを"Level"の"Save RGB"の項目に移動
- X1ボタンを削除
- Imageメニュー(旧View imageボタン)のデフォルトを表示状態をONに
- ImageメニューON時に表示する画像の下の文字情報に"Zoom"文字を追加し、表示時間を削除

### デバッグ
- ショートカットキーでScan Imageを操作したあと、Trace Image表示にすると画像が合わなくなるバグを修正
