### PR TITLE
Fix error: ‘numeric_limits’ is not a member of ‘std’

### DIFF
--- a/sources/libcpp83gts_callback_and_action/fl_gl_image_view.cpp
+++ b/sources/libcpp83gts_callback_and_action/fl_gl_image_view.cpp
@@ -1,6 +1,7 @@
 #include <iostream>	//std::cout
 #include <cstdlib>
 #include <algorithm>	// std::sort()
+#include <limits>       // std::numerical_limits
 #include <sstream>
 #include "FL/fl_ask.H"  // fl_alert(-)
 #include "pri.h"


### PR DESCRIPTION
Resolves #148